### PR TITLE
Fix for reverse proxy server lookup

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -1179,7 +1179,11 @@ class Auth
 
 	private function getIp()
 	{
-		return $_SERVER['REMOTE_ADDR'];
+		if(isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARTDED_FOR'] != '') {
+		   return $_SERVER['HTTP_X_FORWARDED_FOR'];
+		} else {
+		   return $_SERVER['REMOTE_ADDR'];
+		}
 	}
 }
 

--- a/auth.class.php
+++ b/auth.class.php
@@ -1179,7 +1179,7 @@ class Auth
 
 	private function getIp()
 	{
-		if(isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARTDED_FOR'] != '') {
+		if(isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR'] != '') {
 		   return $_SERVER['HTTP_X_FORWARDED_FOR'];
 		} else {
 		   return $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
If you are behind a reverse proxy (as android chrome is by default) the REMOTE_ADDR will always be the IP of the proxy server and the user IP will be provided in an HTTP header (X-Forwarded-For).