### PR TITLE
fixed missing $addRequest definition

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -235,8 +235,9 @@ class Auth
 			$return['message'] = $this->lang["email_incorrect"];
 			return $return;
 		}
-
-		if ($this->addRequest($query->fetch(PDO::FETCH_ASSOC)['id'], $email, "reset")['error'] == 1) {
+		
+		$addRequest = $this->addRequest($query->fetch(PDO::FETCH_ASSOC)['id'], $email, "reset");
+		if ($addRequest['error'] == 1) {
 			$this->addAttempt();
 
 			$return['message'] = $addRequest['message'];


### PR DESCRIPTION
$addrequest= missed on line 239

if ($addRequest = $this->addRequest($query->fetch(PDO::FETCH_ASSOC)['id'], $email, "reset")['error'] == 1)

but due to the way the line of the code is writen, this won't work on my server.
fixed it by defining $addRequest separatly