### PR TITLE
Additional registration params empty -> invalid query

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -493,16 +493,18 @@ class Auth
 		}
 
 		$password = $this->getHash($password);
-
-		$customParamsQueryArray = Array();
-
-		foreach($params as $paramKey => $paramValue) {
-			$customParamsQueryArray[] = array('value' => $paramKey . ' = ?');
+		
+		if (is_array($params)&& count($params) > 0) {
+			$customParamsQueryArray = Array();
+	
+			foreach($params as $paramKey => $paramValue) {
+				$customParamsQueryArray[] = array('value' => $paramKey . ' = ?');
+			}
+	
+			$setParams = ', ' . implode(', ', array_map(function ($entry) {
+				return $entry['value'];
+			}, $customParamsQueryArray));
 		}
-
-		$setParams = ', ' . implode(', ', array_map(function ($entry) {
-			return $entry['value'];
-		}, $customParamsQueryArray));
 
 		$query = $this->dbh->prepare("UPDATE {$this->config->table_users} SET email = ?, password = ? {$setParams} WHERE id = ?");
 


### PR DESCRIPTION
If you don't specify any additional params while calling PHPAuth->register the addUser() function adds a comma after the password resulting in a invalid query
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/95?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/95'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>