### PR TITLE
Advanced attack mitigation attempts are always 0

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -1154,7 +1154,7 @@ class Auth
 	{
 		$ip = $this->getIp();
         $this->deleteAttempts($ip, false);
-		$query = $this->dbh->prepare("SELECT count, expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
+		$query = $this->dbh->prepare("SELECT expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
 		$query->execute(array($ip));
 
         $attempts = $query->rowCount();


### PR DESCRIPTION
The query to get attempts in function isBlocked() asks for the 'count' column that has been removed in #99 and the  following rowCount returns always zero. Removing the count column fixes the error.