### PR TITLE
Advanced attack mitigation doesn't delete expired attempts

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -1213,7 +1213,7 @@ class Auth
         }
 
 
-        $query = $this->dbh->prepare("SELECT count, expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
+        $query = $this->dbh->prepare("SELECT expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
         $query->execute(array($ip));
 
         while ($row = $query->fetch(\PDO::FETCH_ASSOC)) {

--- a/auth.class.php
+++ b/auth.class.php
@@ -1213,7 +1213,7 @@ class Auth
         }
 
 
-        $query = $this->dbh->prepare("SELECT expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
+        $query = $this->dbh->prepare("SELECT id, expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
         $query->execute(array($ip));
 
         while ($row = $query->fetch(\PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
The query in deleteAttempts asks for the count column that doesn't exists and return 0 rows.
Attempts are never removed. Removing the 'count' column from the query fixes the problem.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/105%23issuecomment-140238304%22%2C%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/105%23issuecomment-140239913%22%2C%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/105%23issuecomment-140248767%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/105%23issuecomment-140238304%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20problem%2C%20I%20made%20a%20mistake%20too%2C%20please%20refuse%20this%20pull%2C%20the%20%27id%27%20is%20missing%20in%20the%20query.%22%2C%20%22created_at%22%3A%20%222015-09-15T00%3A11%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4438193%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bugada%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20the%20missing%20id.%20Now%20%20this%20pull%20is%20complete.%22%2C%20%22created_at%22%3A%20%222015-09-15T00%3A21%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4438193%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bugada%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-09-15T01%3A37%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/Conver%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/Conver'><img src='https://avatars.githubusercontent.com/u/6231022?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/PHPAuth/PHPAuth/pull/105#issuecomment-140238304'>General Comment</a></b>
- <a href='https://github.com/bugada'><img border=0 src='https://avatars.githubusercontent.com/u/4438193?v=3' height=16 width=16'></a> No problem, I made a mistake too, please refuse this pull, the 'id' is missing in the query.
- <a href='https://github.com/bugada'><img border=0 src='https://avatars.githubusercontent.com/u/4438193?v=3' height=16 width=16'></a> Fixed the missing id. Now  this pull is complete.


<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/105?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/105?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/105?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/105'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>