### PR TITLE
bugfix PHP error undefined variable in register class.

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -526,7 +526,7 @@ class Auth
 			$setParams = ', ' . implode(', ', array_map(function ($entry) {
 				return $entry['value'];
 			}, $customParamsQueryArray));
-		}
+		} else { $setParams = '';}
 
 		$query = $this->dbh->prepare("UPDATE {$this->config->table_users} SET email = ?, password = ? {$setParams} WHERE id = ?");
 


### PR DESCRIPTION
Previous logic resulted in $setParams as empty string when calling register method without additional params. This throws error on PHP server depending on settings.

Corrected by assigning empty string conditionally.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/Conver%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/109%23issuecomment-140903135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-09-16T21%3A45%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/109%23issuecomment-140903135%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/Conver'><img src='https://avatars.githubusercontent.com/u/6231022?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/109?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/109?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/109'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>