### PR TITLE
Inefficient count system

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -472,10 +472,10 @@ class Auth
 
 	public function isEmailTaken($email)
 	{
-		$query = $this->dbh->prepare("SELECT * FROM {$this->config->table_users} WHERE email = ?");
+		$query = $this->dbh->prepare("SELECT count(*) FROM {$this->config->table_users} WHERE email = ?");
 		$query->execute(array($email));
 
-		if ($query->rowCount() == 0) {
+		if ($query->fetchColumn() == 0) {
 			return false;
 		}
 
@@ -1152,12 +1152,12 @@ class Auth
 
 	public function isBlocked()
 	{
-		$ip = $this->getIp();
-        $this->deleteAttempts($ip, false);
-		$query = $this->dbh->prepare("SELECT expiredate FROM {$this->config->table_attempts} WHERE ip = ?");
-		$query->execute(array($ip));
+		  $ip = $this->getIp();
+		  $this->deleteAttempts($ip, false);
+		  $query = $this->dbh->prepare("SELECT count(*) FROM {$this->config->table_attempts} WHERE ip = ?");
+    	  $query->execute(array($ip));
 
-        $attempts = $query->rowCount();
+        $attempts = $query->fetchColumn();
 
         if($attempts < intval($this->config->attempts_before_verify))
         {


### PR DESCRIPTION
Better use select count(*) instead of $query->rowCount() when not using others fetched params.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/111?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/111'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>