### PR TITLE
Bugfix suggested by JacquesLoubser, avoids sending empty email

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -733,15 +733,17 @@ class Auth
 			$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
 		}
 
-		if(!$mail->send() && !$suppressed) {
+		if($suppressed){
+			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
+			$return['error'] = false;
+			return $return;
+		}
+
+		if(!$mail->send()) {
 			$this->deleteRequest($request_id);
 
 			$return['message'] = $this->lang["system_error"] . " #10";
 			return $return;
-		}
-
-		if($suppressed){
-			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
 		}
 
 		$return['error'] = false;


### PR DESCRIPTION
Resolves issue where testing if !$mail->send() would generate empty email into space when email suppressed.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/114?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/114'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>