### PR TITLE
Augmenting the suppressed functionality with messaging and languages (properly this time)

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -675,7 +675,7 @@ class Auth
 	* @return boolean
 	*/
 
-	private function addRequest($uid, $email, $type,$suppressed = NULL)
+	private function addRequest($uid, $email, $type, $suppressed = NULL)
 	{
 
 

--- a/auth.class.php
+++ b/auth.class.php
@@ -728,18 +728,13 @@ class Auth
 				$suppressed = true;
 			}
 		} else {
-			if(!$this->config->emailmessage_suppress_reset){
-				$mail->Subject = sprintf($this->lang['email_reset_subject'], $this->config->site_name);
-				$mail->Body = sprintf($this->lang['email_reset_body'], $this->config->site_url, $this->config->site_password_reset_page, $key);
-				$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
-			} else {
-				$suppressed = true;
-			}
+			$mail->Subject = sprintf($this->lang['email_reset_subject'], $this->config->site_name);
+			$mail->Body = sprintf($this->lang['email_reset_body'], $this->config->site_url, $this->config->site_password_reset_page, $key);
+			$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
 		}
 
 		if($suppressed){
 			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
-			$this->lang["reset_requested"] = $this->lang["reset_requested_emailmessage_suppressed"];
 			$return['error'] = false;
 			return $return;
 		}

--- a/auth.class.php
+++ b/auth.class.php
@@ -733,15 +733,17 @@ class Auth
 			$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
 		}
 
-		if(!$mail->send() && !$suppressed) {
+		if($suppressed){
+			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
+			$return['error'] = false;
+			return $return;
+		}
+
+		if(!$mail->send()) {
 			$this->deleteRequest($request_id);
 
 			$return['message'] = $this->lang["system_error"] . " #10";
 			return $return;
-		}
-
-		if($suppressed){
-			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
 		}
 
 		$return['error'] = false;

--- a/auth.class.php
+++ b/auth.class.php
@@ -728,13 +728,18 @@ class Auth
 				$suppressed = true;
 			}
 		} else {
-			$mail->Subject = sprintf($this->lang['email_reset_subject'], $this->config->site_name);
-			$mail->Body = sprintf($this->lang['email_reset_body'], $this->config->site_url, $this->config->site_password_reset_page, $key);
-			$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
+			if(!$this->config->emailmessage_suppress_reset){
+				$mail->Subject = sprintf($this->lang['email_reset_subject'], $this->config->site_name);
+				$mail->Body = sprintf($this->lang['email_reset_body'], $this->config->site_url, $this->config->site_password_reset_page, $key);
+				$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
+			} else {
+				$suppressed = true;
+			}
 		}
 
 		if($suppressed){
 			$this->lang["register_success"] = $this->lang["register_success_emailmessage_suppressed"];
+			$this->lang["reset_requested"] = $this->lang["reset_requested_emailmessage_suppressed"];
 			$return['error'] = false;
 			return $return;
 		}

--- a/auth.class.php
+++ b/auth.class.php
@@ -693,6 +693,8 @@ class Auth
                if(!$this->config->emailmessage_suppress_activation)
                {
                    $suppressed = false;
+               } else {
+               		$lang['register_success']=$lang['register_success_emailmessage_suppressed']
                }
            }
            if($type == "reset")
@@ -700,6 +702,8 @@ class Auth
                if(!$this->config->emailmessage_suppress_reset)
                {
                    $suppressed = false;
+               } else {
+               		$lang['reset_requested']=$lang['reset_requested_emailmessage_suppressed']
                }
            }
 

--- a/config.class.php
+++ b/config.class.php
@@ -111,8 +111,5 @@ class Config
         if (! isset($this->config['emailmessage_suppress_activation']) )
             $this->config['emailmessage_suppress_activation'] = 0;
 
-        if (! isset($this->config['emailmessage_suppress_reset']) )
-            $this->config['emailmessage_suppress_reset'] = 0;
-
     }
 }

--- a/config.class.php
+++ b/config.class.php
@@ -32,7 +32,7 @@ class Config
             $this->config[$row['setting']] = $row['value'];
         }
 
-        $this->setVerifyDefaults(); // Danger foreseen is half avoided.
+        $this->setForgottenDefaults(); // Danger foreseen is half avoided.
     }
 
     /**
@@ -70,7 +70,7 @@ class Config
      * Set default values.
      * REQUIRED FOR USERS THAT DOES NOT UPDATE THEIR `config` TABLES.
      */
-    private function setVerifyDefaults()
+    private function setForgottenDefaults()
     {
         // verify* values.
 

--- a/config.class.php
+++ b/config.class.php
@@ -65,6 +65,20 @@ class Config
     }
 
     /**
+     * Config::override()
+     * 
+     * @param mixed $setting
+     * @param mixed $value
+     * @return bool
+     */
+    public function override($setting, $value){
+
+        $this->config[$setting] = $value;
+        return true;
+
+    }
+
+    /**
      * Danger foreseen is half avoided.
      *
      * Set default values.

--- a/config.class.php
+++ b/config.class.php
@@ -111,5 +111,8 @@ class Config
         if (! isset($this->config['emailmessage_suppress_activation']) )
             $this->config['emailmessage_suppress_activation'] = 0;
 
+        if (! isset($this->config['emailmessage_suppress_reset']) )
+            $this->config['emailmessage_suppress_reset'] = 0;
+
     }
 }

--- a/config.class.php
+++ b/config.class.php
@@ -111,6 +111,9 @@ class Config
         if (! isset($this->config['emailmessage_suppress_activation']) )
             $this->config['emailmessage_suppress_activation'] = 0;
 
+        if (! isset($this->config['emailmessage_suppress_reset']) )
+            $this->config['emailmessage_suppress_reset'] = 0;
+
     }
 
 

--- a/database.sql
+++ b/database.sql
@@ -11,7 +11,7 @@ CREATE TABLE `config` (
   `setting` varchar(100) NOT NULL,
   `value` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
 
 INSERT INTO `config` (`id`, `setting`, `value`) VALUES
 (1,	    'site_name',	'PHPAuth'),
@@ -49,7 +49,8 @@ INSERT INTO `config` (`id`, `setting`, `value`) VALUES
 (33,    'attack_mitigation_time', '+30 minutes'),
 (34,    'attempts_before_verify', '5'),
 (35,    'attempts_before_ban', '30'),
-(36,    'emailmessage_suppress_activation', '0');
+(36,    'emailmessage_suppress_activation', '0'),
+(37,    'emailmessage_suppress_reset', '0');
 
 DROP TABLE IF EXISTS `attempts`;
 CREATE TABLE `attempts` (

--- a/database.sql
+++ b/database.sql
@@ -11,7 +11,7 @@ CREATE TABLE `config` (
   `setting` varchar(100) NOT NULL,
   `value` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
 
 INSERT INTO `config` (`id`, `setting`, `value`) VALUES
 (1,	    'site_name',	'PHPAuth'),
@@ -49,8 +49,7 @@ INSERT INTO `config` (`id`, `setting`, `value`) VALUES
 (33,    'attack_mitigation_time', '+30 minutes'),
 (34,    'attempts_before_verify', '5'),
 (35,    'attempts_before_ban', '30'),
-(36,    'emailmessage_suppress_activation', '0'),
-(37,    'emailmessage_suppress_reset', '0');
+(36,    'emailmessage_suppress_activation', '0');
 
 DROP TABLE IF EXISTS `attempts`;
 CREATE TABLE `attempts` (

--- a/languages/de_DE.php
+++ b/languages/de_DE.php
@@ -53,7 +53,6 @@ $lang['activationkey_incorrect'] = "Aktivierungsschlüssel ist nicht korrekt.";
 $lang['activationkey_expired'] = "Aktivierungsschlüssel ist abgelaufen.";
 
 $lang['reset_requested'] = "Wir haben dir eine E-Mail zum Zurücksetzen deines Passworts geschickt.";
-$lang['reset_requested_emailmessage_suppressed'] = "Erstellt Anforderung an Passwort zurückzusetzen.";
 $lang['reset_exists'] = "Es liegt bereits eine Anfrage zum Zurücksetzen deines Passworts vor.";
 
 $lang['already_activated'] = "Benutzerkonto ist bereits aktiviert.";

--- a/languages/de_DE.php
+++ b/languages/de_DE.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "Aktivierungsschlüssel ist nicht korrekt.";
 $lang['activationkey_expired'] = "Aktivierungsschlüssel ist abgelaufen.";
 
 $lang['reset_requested'] = "Wir haben dir eine E-Mail zum Zurücksetzen deines Passworts geschickt.";
+$lang['reset_requested_emailmessage_suppressed'] = "Erstellt Anforderung an Passwort zurückzusetzen.";
 $lang['reset_exists'] = "Es liegt bereits eine Anfrage zum Zurücksetzen deines Passworts vor.";
 
 $lang['already_activated'] = "Benutzerkonto ist bereits aktiviert.";

--- a/languages/en_GB.php
+++ b/languages/en_GB.php
@@ -54,6 +54,7 @@ $lang['activationkey_incorrect'] = "Activation key is incorrect.";
 $lang['activationkey_expired'] = "Activation key has expired.";
 
 $lang['reset_requested'] = "Password reset request sent to email address.";
+$lang['reset_requested_emailmessage_suppressed'] = "Password reset request is created.";
 $lang['reset_exists'] = "A reset request already exists.";
 
 $lang['already_activated'] = "Account is already activated.";

--- a/languages/en_GB.php
+++ b/languages/en_GB.php
@@ -54,7 +54,6 @@ $lang['activationkey_incorrect'] = "Activation key is incorrect.";
 $lang['activationkey_expired'] = "Activation key has expired.";
 
 $lang['reset_requested'] = "Password reset request sent to email address.";
-$lang['reset_requested_emailmessage_suppressed'] = "Password reset request is created.";
 $lang['reset_exists'] = "A reset request already exists.";
 
 $lang['already_activated'] = "Account is already activated.";

--- a/languages/fr_FR.php
+++ b/languages/fr_FR.php
@@ -53,7 +53,6 @@ $lang['activationkey_incorrect'] = "La cl&eacute; d'activation est incorrecte.";
 $lang['activationkey_expired'] = "La cl&eacute; d'activation est expir&eacute;e.";
 
 $lang['reset_requested'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacute;t&eacute; envoy&eacute;.";
-$lang['reset_requested_emailmessage_suppressed'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacutet&eacute cr&eacute&eacute.";
 $lang['reset_exists'] = "Une demande de r&eacute;initialisation de votre mot de passe existe d&eacute;j&agrave;.";
 
 $lang['already_activated'] = "Le compte est d&eacute;j&agrave; activ&eacute;.";

--- a/languages/fr_FR.php
+++ b/languages/fr_FR.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "La cl&eacute; d'activation est incorrecte.";
 $lang['activationkey_expired'] = "La cl&eacute; d'activation est expir&eacute;e.";
 
 $lang['reset_requested'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacute;t&eacute; envoy&eacute;.";
+$lang['reset_requested_emailmessage_suppressed'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacutet&eacute cr&eacute&eacute.";
 $lang['reset_exists'] = "Une demande de r&eacute;initialisation de votre mot de passe existe d&eacute;j&agrave;.";
 
 $lang['already_activated'] = "Le compte est d&eacute;j&agrave; activ&eacute;.";

--- a/languages/it_IT.php
+++ b/languages/it_IT.php
@@ -54,7 +54,6 @@ $lang['activationkey_incorrect'] = 'Il codice attivazione non &egrave; corretto'
 $lang['activationkey_expired'] = 'Il codice attivazione &egrave; scaduto.';
 
 $lang['reset_requested'] = 'Codice per il reset della password spedito all&quot;indirizzo email associato all&quot;account.';
-$lang['reset_requested_emailmessage_suppressed'] = 'Codice per il reset della password stato creato.';
 $lang['reset_exists'] = '&Egrave; gi&agrave; stato richiesto il reset della password.';
 
 $lang['already_activated'] = 'L&quot;account &egrave; gi&agrave; in stato attivo.';

--- a/languages/it_IT.php
+++ b/languages/it_IT.php
@@ -54,6 +54,7 @@ $lang['activationkey_incorrect'] = 'Il codice attivazione non &egrave; corretto'
 $lang['activationkey_expired'] = 'Il codice attivazione &egrave; scaduto.';
 
 $lang['reset_requested'] = 'Codice per il reset della password spedito all&quot;indirizzo email associato all&quot;account.';
+$lang['reset_requested_emailmessage_suppressed'] = 'Codice per il reset della password stato creato.';
 $lang['reset_exists'] = '&Egrave; gi&agrave; stato richiesto il reset della password.';
 
 $lang['already_activated'] = 'L&quot;account &egrave; gi&agrave; in stato attivo.';

--- a/languages/ru_RU.php
+++ b/languages/ru_RU.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "Неверный ключ акцивации
 $lang['activationkey_expired'] = "Срок действия ключа активации истёк!";
 
 $lang['reset_requested'] = "Запрос на сброс пароля выслан по почте.";
+$lang['reset_requested_emailmessage_suppressed'] = "Запрос сброса пароля создан.";
 $lang['reset_exists'] = "Сброс пароля уже запрошен.";
 $lang['password_reset'] = "Пароль сброшен успешно.";
 

--- a/languages/ru_RU.php
+++ b/languages/ru_RU.php
@@ -53,7 +53,6 @@ $lang['activationkey_incorrect'] = "Неверный ключ акцивации
 $lang['activationkey_expired'] = "Срок действия ключа активации истёк!";
 
 $lang['reset_requested'] = "Запрос на сброс пароля выслан по почте.";
-$lang['reset_requested_emailmessage_suppressed'] = "Запрос сброса пароля создан.";
 $lang['reset_exists'] = "Сброс пароля уже запрошен.";
 $lang['password_reset'] = "Пароль сброшен успешно.";
 


### PR DESCRIPTION
Sorry about the earlier confusion, this commit should merge correctly and adds back in the messaging features for both suppression flags.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/119%23issuecomment-142046115%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/119%23issuecomment-142046115%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nope%22%2C%20%22created_at%22%3A%20%222015-09-21T17%3A14%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4187179%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ChristinMilloy%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/PHPAuth/PHPAuth/pull/119#issuecomment-142046115'>General Comment</a></b>
- <a href='https://github.com/ChristinMilloy'><img border=0 src='https://avatars.githubusercontent.com/u/4187179?v=3' height=16 width=16'></a> nope


<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/119?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/119?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/119'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>