### PR TITLE
Reimplemented language messages for suppressed emails

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -675,7 +675,7 @@ class Auth
 	* @return boolean
 	*/
 
-	private function addRequest($uid, $email, $type,$suppressed = NULL)
+	private function addRequest($uid, $email, $type, $suppressed = NULL)
 	{
 
 
@@ -693,6 +693,8 @@ class Auth
                if(!$this->config->emailmessage_suppress_activation)
                {
                    $suppressed = false;
+               } else {
+               		$this->lang['register_success']=$this->lang['register_success_emailmessage_suppressed'];
                }
            }
            if($type == "reset")
@@ -700,6 +702,8 @@ class Auth
                if(!$this->config->emailmessage_suppress_reset)
                {
                    $suppressed = false;
+               } else {
+               	  $this->lang['reset_requested']=$this->lang['reset_requested_emailmessage_suppressed'];
                }
            }
 
@@ -775,8 +779,6 @@ class Auth
 			$mail->Body = sprintf($this->lang['email_reset_body'], $this->config->site_url, $this->config->site_password_reset_page, $key);
 			$mail->AltBody = sprintf($this->lang['email_reset_altbody'], $this->config->site_url, $this->config->site_password_reset_page, $key);
 		}
-
-
 
 		if(!$mail->send()) {
 			$this->deleteRequest($request_id);

--- a/database.sql
+++ b/database.sql
@@ -11,7 +11,7 @@ CREATE TABLE `config` (
   `setting` varchar(100) NOT NULL,
   `value` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
 
 INSERT INTO `config` (`id`, `setting`, `value`) VALUES
 (1,	    'site_name',	'PHPAuth'),

--- a/languages/de_DE.php
+++ b/languages/de_DE.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "Aktivierungsschlüssel ist nicht korrekt.";
 $lang['activationkey_expired'] = "Aktivierungsschlüssel ist abgelaufen.";
 
 $lang['reset_requested'] = "Wir haben dir eine E-Mail zum Zurücksetzen deines Passworts geschickt.";
+$lang['reset_requested_emailmessage_suppressed'] = "Erstellt Anforderung an Passwort zurückzusetzen.";
 $lang['reset_exists'] = "Es liegt bereits eine Anfrage zum Zurücksetzen deines Passworts vor.";
 
 $lang['already_activated'] = "Benutzerkonto ist bereits aktiviert.";

--- a/languages/en_GB.php
+++ b/languages/en_GB.php
@@ -54,6 +54,7 @@ $lang['activationkey_incorrect'] = "Activation key is incorrect.";
 $lang['activationkey_expired'] = "Activation key has expired.";
 
 $lang['reset_requested'] = "Password reset request sent to email address.";
+$lang['reset_requested_emailmessage_suppressed'] = "Password reset request is created.";
 $lang['reset_exists'] = "A reset request already exists.";
 
 $lang['already_activated'] = "Account is already activated.";

--- a/languages/fr_FR.php
+++ b/languages/fr_FR.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "La cl&eacute; d'activation est incorrecte.";
 $lang['activationkey_expired'] = "La cl&eacute; d'activation est expir&eacute;e.";
 
 $lang['reset_requested'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacute;t&eacute; envoy&eacute;.";
+$lang['reset_requested_emailmessage_suppressed'] = "Une demande de r&eacute;initialisation de votre mot de passe a &eacutet&eacute cr&eacute&eacute.";
 $lang['reset_exists'] = "Une demande de r&eacute;initialisation de votre mot de passe existe d&eacute;j&agrave;.";
 
 $lang['already_activated'] = "Le compte est d&eacute;j&agrave; activ&eacute;.";

--- a/languages/it_IT.php
+++ b/languages/it_IT.php
@@ -54,6 +54,7 @@ $lang['activationkey_incorrect'] = 'Il codice attivazione non &egrave; corretto'
 $lang['activationkey_expired'] = 'Il codice attivazione &egrave; scaduto.';
 
 $lang['reset_requested'] = 'Codice per il reset della password spedito all&quot;indirizzo email associato all&quot;account.';
+$lang['reset_requested_emailmessage_suppressed'] = 'Codice per il reset della password stato creato.';
 $lang['reset_exists'] = '&Egrave; gi&agrave; stato richiesto il reset della password.';
 
 $lang['already_activated'] = 'L&quot;account &egrave; gi&agrave; in stato attivo.';

--- a/languages/ru_RU.php
+++ b/languages/ru_RU.php
@@ -53,6 +53,7 @@ $lang['activationkey_incorrect'] = "Неверный ключ акцивации
 $lang['activationkey_expired'] = "Срок действия ключа активации истёк!";
 
 $lang['reset_requested'] = "Запрос на сброс пароля выслан по почте.";
+$lang['reset_requested_emailmessage_suppressed'] = "Запрос сброса пароля создан.";
 $lang['reset_exists'] = "Сброс пароля уже запрошен.";
 $lang['password_reset'] = "Пароль сброшен успешно.";
 


### PR DESCRIPTION
This time completely hard reset my local master first per JacquesLoubser.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/121%23issuecomment-142060232%22%2C%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/121%23issuecomment-142061793%22%2C%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/121%23issuecomment-142063214%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/121%23issuecomment-142060232%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20is%20your%20PR%20meant%20to%20do%3F%5Cr%5Cn%5Cr%5CnI%20dont%20really%20see%20anything%20beside%20adding%20%60%24this-%3Elang%5B%27reset_requested%27%5D%3D%24this-%3Elang%5B%27reset_requested_emailmessage_suppressed%27%5D%3B%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-21T17%3A53%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20idea%20is%20that%20it%20changes%20the%20output%20messages%20when%20email%20is%20suppressed%20so%5Cnthat%20it%20doesn%27t%20tell%20the%20user%20%5C%22email%20was%20sent.%5C%22%5Cn%5CnI%20put%20in%20alternate%20messages%20for%20both%20states%20in%20all%20languages.%5Cn%5CnOn%20Mon%2C%20Sep%2021%2C%202015%2C%2013%3A53%20Geekologist%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20What%20is%20your%20PR%20meant%20to%20do%3F%5Cn%3E%5Cn%3E%20I%20dont%20really%20see%20anything%20beside%20adding%5Cn%3E%20%24this-%3Elang%5B%27reset_requested%27%5D%3D%24this-%3Elang%5B%27reset_requested_emailmessage_suppressed%27%5D%3B%5Cn%3E%20%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/PHPAuth/PHPAuth/pull/121%23issuecomment-142060232%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-21T18%3A00%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4187179%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ChristinMilloy%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-09-21T18%3A05%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/Conver%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/Conver'><img src='https://avatars.githubusercontent.com/u/6231022?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/PHPAuth/PHPAuth/pull/121#issuecomment-142060232'>General Comment</a></b>
- <a href='https://github.com/Conver'><img border=0 src='https://avatars.githubusercontent.com/u/6231022?v=3' height=16 width=16'></a> What is your PR meant to do?
I dont really see anything beside adding `$this->lang['reset_requested']=$this->lang['reset_requested_emailmessage_suppressed'];` ?
- <a href='https://github.com/ChristinMilloy'><img border=0 src='https://avatars.githubusercontent.com/u/4187179?v=3' height=16 width=16'></a> The idea is that it changes the output messages when email is suppressed so
that it doesn't tell the user "email was sent."
I put in alternate messages for both states in all languages.
On Mon, Sep 21, 2015, 13:53 Geekologist <notifications@github.com> wrote:
> What is your PR meant to do?
>
> I dont really see anything beside adding
> $this->lang['reset_requested']=$this->lang['reset_requested_emailmessage_suppressed'];
> ?
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/PHPAuth/PHPAuth/pull/121#issuecomment-142060232>.
>


<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/121?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/121?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/121?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/121'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>