### PR TITLE
account creation  : activation key problem fix

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -514,7 +514,9 @@ class Auth
 			$return['message'] = $addRequest['message'];
 			return $return;
 		}
-
+		
+		$isactive = ($sendmail === false ? 1 : 0);
+		
 		$password = $this->getHash($password);
 		
 		if (is_array($params)&& count($params) > 0) {
@@ -529,9 +531,9 @@ class Auth
 			}, $customParamsQueryArray));
 		} else { $setParams = ''; }
 
-		$query = $this->dbh->prepare("UPDATE {$this->config->table_users} SET email = ?, password = ? {$setParams} WHERE id = ?");
+		$query = $this->dbh->prepare("UPDATE {$this->config->table_users} SET email = ?, password = ?, isactive = ? {$setParams} WHERE id = ?");
 
-		$bindParams = array_values(array_merge(array($email, $password), $params, array($uid)));
+		$bindParams = array_values(array_merge(array($email, $password, $isactive), $params, array($uid)));
 
 		if(!$query->execute($bindParams)) {
 			$query = $this->dbh->prepare("DELETE FROM {$this->config->table_users} WHERE id = ?");
@@ -691,9 +693,13 @@ class Auth
 			$sendmail = true;			
 			if($type == "reset" && $this->config->emailmessage_suppress_reset === true ) {
 				$sendmail = false;
+				$return['error'] = false;
+				return $return;
 			} 
 			if ($type == "activation" && $this->config->emailmessage_suppress_activation === true ) {
 				$sendmail = false;
+				$return['error'] = false;
+				return $return;
 			}
 		}			
 	


### PR DESCRIPTION
the fix for account creation without mail, but activation key created
now if $sendmail is set to FALSE, addRequest is ignored  and the account is activated.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/124%23issuecomment-143018447%22%2C%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/124%23issuecomment-143146500%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/124%23issuecomment-143018447%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wouldn%27t%20it%20be%20easier%20just%20adding%20it%20to%20the%20config%20table%2C%20if%20the%20user%20wish%20to%20use%20it%20or%20not%2C%20instead%20of%20having%20to%20alter%20the%20code%3F%22%2C%20%22created_at%22%3A%20%222015-09-24T18%3A53%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%2C%20%7B%22body%22%3A%20%22sendmail%20is%20allready%20defined%20in%20config%20table%20for%20global%20configuration.%5Cr%5Cnbut%20i%27ve%20added%20a%20manual%20overwrite%20in%20need%20of%20a%20specific%20action.%5Cr%5Cnif%20config%20table%20say%20to%20send%20a%20mail%20and%20nothing%20is%20set%20on%20form%20validation%2C%20mail%20is%20sent.%5Cr%5Cnif%20the%20developer%20have%20built%20an%20admin%20page%20to%20manage%20users%20and%20want%20to%20create%20accounts%20without%20sending%20mail%2C%20an%20option%20can%20be%20set%20to%20overwrite%20config%20entry.%5Cr%5Cnand%20the%20same%20thing%20work%20in%20the%20other%20way.%20in%20case%20where%20sending%20mail%20if%20off%20but%20someone%20want%20to%20sent%20it.%5Cr%5Cnthen%2C%20in%20case%20of%20mail%20is%20not%20sent%2C%20account%20created%20need%20to%20be%20activated.%5Cr%5Cn%5Cr%5Cnor%20perhaps%20adding%20a%20new%20method%20who%20list%20all%20pending%20accounds%20and%20autorize%20manual%20activation.%22%2C%20%22created_at%22%3A%20%222015-09-25T07%3A09%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1687538%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mooztik%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/PHPAuth/PHPAuth/pull/124#issuecomment-143018447'>General Comment</a></b>
- <a href='https://github.com/Conver'><img border=0 src='https://avatars.githubusercontent.com/u/6231022?v=3' height=16 width=16'></a> Wouldn't it be easier just adding it to the config table, if the user wish to use it or not, instead of having to alter the code?
- <a href='https://github.com/mooztik'><img border=0 src='https://avatars.githubusercontent.com/u/1687538?v=3' height=16 width=16'></a> sendmail is allready defined in config table for global configuration.
but i've added a manual overwrite in need of a specific action.
if config table say to send a mail and nothing is set on form validation, mail is sent.
if the developer have built an admin page to manage users and want to create accounts without sending mail, an option can be set to overwrite config entry.
and the same thing work in the other way. in case where sending mail if off but someone want to sent it.
then, in case of mail is not sent, account created need to be activated.
or perhaps adding a new method who list all pending accounds and autorize manual activation.


<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/124?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/124?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/124'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>