### PR TITLE
reset key invalid if new password matches ol password

### DIFF
--- a/auth.class.php
+++ b/auth.class.php
@@ -967,7 +967,6 @@ class Auth
 
 		if(password_verify($password, $user['password'])) {
 			$this->addAttempt();
-			$this->deleteRequest($data['id']);
 
 			$return['message'] = $this->lang["newpassword_match"];
 			return $return;


### PR DESCRIPTION
During the reset process if the new password matches the old password the request is cancelled from the db and the key became invalid and you have to request a new one.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/Conver%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/PHPAuth/PHPAuth/pull/127%23issuecomment-145509483%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-05T12%3A16%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6231022%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Conver%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/PHPAuth/PHPAuth/pull/127%23issuecomment-145509483%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/Conver'><img src='https://avatars.githubusercontent.com/u/6231022?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/127?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/PHPAuth/PHPAuth/pull/127?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/PHPAuth/PHPAuth/pull/127'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>