### PR TITLE
Update Auth.php

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -791,7 +791,7 @@ class Auth
         if ($sendmail === true) {
             // Check configuration for SMTP parameters
             $mail = new PHPMailer;
-            $mail->CharSet = 'UTF-8';
+			$mail->CharSet = $this->$config->mail_charset;
             if ($this->config->smtp) {
                 $mail->isSMTP();
                 $mail->Host = $this->config->smtp_host;

--- a/Auth.php
+++ b/Auth.php
@@ -791,7 +791,7 @@ class Auth
         if ($sendmail === true) {
             // Check configuration for SMTP parameters
             $mail = new PHPMailer;
-			$mail->CharSet = $this->$config->mail_charset;
+			$mail->CharSet = $this->config->mail_charset;
             if ($this->config->smtp) {
                 $mail->isSMTP();
                 $mail->Host = $this->config->smtp_host;

--- a/Auth.php
+++ b/Auth.php
@@ -791,6 +791,7 @@ class Auth
         if ($sendmail === true) {
             // Check configuration for SMTP parameters
             $mail = new PHPMailer;
+            $mail->CharSet = 'UTF-8';
             if ($this->config->smtp) {
                 $mail->isSMTP();
                 $mail->Host = $this->config->smtp_host;

--- a/Config.php
+++ b/Config.php
@@ -124,6 +124,11 @@ class Config
         if (!isset($this->config['emailmessage_suppress_reset'])) {
             $this->config['emailmessage_suppress_reset'] = 0;
         }
-    }
+		
+		if (!isset($this->config['mail_charset'])) {
+            $this->config['mail_charset'] = "UTF-8";
+        }
+	}
+	
 
 }

--- a/database_mysql.sql
+++ b/database_mysql.sql
@@ -5,8 +5,6 @@ SET time_zone = '+00:00';
 SET foreign_key_checks = 0;
 SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 
-USE phpauth;
-
 DROP TABLE IF EXISTS `attempts`;
 CREATE TABLE `attempts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/database_mysql.sql
+++ b/database_mysql.sql
@@ -5,6 +5,8 @@ SET time_zone = '+00:00';
 SET foreign_key_checks = 0;
 SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 
+USE phpauth;
+
 DROP TABLE IF EXISTS `attempts`;
 CREATE TABLE `attempts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -35,6 +37,7 @@ INSERT INTO `config` (`setting`, `value`) VALUES
 ('cookie_secure', '0'),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
+('mail_charset','UTF-8'),
 ('password_min_score',  '3'),
 ('site_activation_page',  'activate'),
 ('site_email',  'no-reply@phpauth.cuonic.com'),

--- a/database_pgsql.sql
+++ b/database_pgsql.sql
@@ -19,6 +19,7 @@ INSERT INTO config (setting, value) VALUES
 ('cookie_secure', '0'),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
+('mail_charset','UTF-8'),
 ('password_min_score',  '3'),
 ('site_activation_page',  'activate'),
 ('site_email',  'no-reply@phpauth.cuonic.com'),


### PR DESCRIPTION
The e-mails sent by PHPMailer will now display non-ASCII characters correctly. Tested in the Czech language.