### PR TITLE
Minor spelling mistakes

### DIFF
--- a/languages/nl_BE.php
+++ b/languages/nl_BE.php
@@ -4,8 +4,8 @@ $lang = array();
 $lang['user_blocked'] = "Je bent momenteel uitgesloten van het systeem.";
 $lang['user_verify_failed'] = "De Captcha Code is niet juist.";
 
-$lang['email_password_invalid'] = "Je e-mail addres en/of passwoord zijn niet juist.";
-$lang['email_password_incorrect'] = "Je e-mail addres en/of passwoord is fout.";
+$lang['email_password_invalid'] = "Je e-mail adres en/of paswoord zijn niet juist.";
+$lang['email_password_incorrect'] = "Je e-mail adres en/of paswoord is fout.";
 $lang['remember_me_invalid'] = "Het \"remember me\" veld is niet juist.";
 
 $lang['password_short'] = "Je gekozen paswoord is te kort.";

--- a/languages/nl_NL.php
+++ b/languages/nl_NL.php
@@ -4,11 +4,11 @@ $lang = array();
 $lang['user_blocked'] = "Je bent momenteel uitgesloten van het systeem.";
 $lang['user_verify_failed'] = "De Captcha code is niet juist.";
 
-$lang['email_password_invalid'] = "Je e-mail addres en/of wachtwoord zijn niet juist.";
-$lang['email_password_incorrect'] = "Je e-mail addres en/of wachtwoord is fout.";
+$lang['email_password_invalid'] = "Je e-mail adres en/of wachtwoord zijn niet juist.";
+$lang['email_password_incorrect'] = "Je e-mail adres en/of wachtwoord is fout.";
 $lang['remember_me_invalid'] = "Het \"remember me\" veld is niet juist.";
 
-$lang['password_short'] = "Je gekozen paswoord is te kort.";
+$lang['password_short'] = "Je gekozen wachtwoord is te kort.";
 $lang['password_weak'] = "Je gekozen wachtwoord is niet complex genoeg.";
 $lang['password_nomatch'] = "De wachtwoorden zijn niet gelijk.";
 $lang['password_changed'] = "Je wachtwoord is met success aangepast.";


### PR DESCRIPTION
In dutch we tend to say 'Wachtwoord' instead of 'Paswoord'. Also, addres and address are both incorrect in both languages