### PR TITLE
Stop fetching request twice

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -300,7 +300,7 @@ class Auth
             return $return;
         }
 
-        $addRequest = $this->addRequest($query->fetch(\PDO::FETCH_ASSOC)['id'], $email, "reset", $sendmail);
+        $addRequest = $this->addRequest($row['id'], $email, "reset", $sendmail);
 
         if ($addRequest['error'] == 1) {
             $this->addAttempt();

--- a/Auth.php
+++ b/Auth.php
@@ -849,8 +849,6 @@ class Auth
             return $return;
         }
 
-        $row = $query->fetch();
-
         $expiredate = strtotime($row['expire']);
         $currentdate = strtotime(date("Y-m-d H:i:s"));
 


### PR DESCRIPTION
I'm unable to validate an activate key's expire date because the row is always fetched twice, causing $row to be false. I see no reason to fetch again. It will also fetch using the default PDO fetchMode. I'm wondering how getRequest can be returning the correct id and uid without this change.
