### PR TITLE
Fix Auth::addUser() for postgresql db

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -531,14 +531,14 @@ class Auth
     {
         $return['error'] = true;
 
-        $query = $this->dbh->prepare("INSERT INTO {$this->config->table_users} VALUES ()");
+        $query = $this->dbh->prepare("INSERT INTO {$this->config->table_users} (isactive) VALUES (0)");
 
         if (!$query->execute()) {
             $return['message'] = $this->lang["system_error"] . " #03";
             return $return;
         }
 
-        $uid = $this->dbh->lastInsertId();
+        $uid = $this->dbh->lastInsertId("{$this->config->table_users}_id_seq");
         $email = htmlentities(strtolower($email));
 
         if ($sendmail) {


### PR DESCRIPTION
1. On the PostgreSQL database statement `INSERT INTO users VALUES ()` fails with the following message:
```
ERROR:  syntax error at or near ")"
LINE 1: INSERT INTO auth_users VALUES ()
                                       ^
```
2. `lastInsertId()` returns `false` for PostgreSQL. Sequence name should be passed.
see: http://stackoverflow.com/questions/10492566/lastinsertid-does-not-work-in-postgresql
