### PR TITLE
Fix phpmailer namespace error

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -3,7 +3,7 @@
 namespace PHPAuth;
 
 use ZxcvbnPhp\Zxcvbn;
-use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer;
 
 /**
  * Auth class


### PR DESCRIPTION
I noticed that use of PHPMailer namespace is incorrect when I wanted to use register() method with $sendmail set to true.

`PHP Fatal error:  Class 'PHPMailer\PHPMailer\PHPMailer' not found in /PHPAuth/Auth.php on line 786`