### PR TITLE
HTTP_USER_AGENT is optional

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -378,7 +378,7 @@ class Auth
         }
 
         $data['hash'] = sha1($this->config->site_key . microtime());
-        $agent = $_SERVER['HTTP_USER_AGENT'];
+        $agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
         $this->deleteExistingSessions($uid);
 


### PR DESCRIPTION
Not all of the clients provides HTTP_USER_AGENT. PHPAuth crashed if was missing.