### PR TITLE
Make current password parameter mandatory for changePassword

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -1108,7 +1108,7 @@ class Auth
     * @param string $captcha = NULL
     * @return array $return
     */
-    public function changePassword($uid, $currpass, $newpass, $repeatnewpass, $captcha = NULL)
+    public function changePassword($uid, $currpass = NULL, $newpass, $repeatnewpass, $captcha = NULL)
     {
         $return['error'] = true;
         $block_status = $this->isBlocked();
@@ -1128,7 +1128,7 @@ class Auth
 
         $validatePassword = $this->validatePassword($currpass);
 
-        if ($validatePassword['error'] == 1) {
+        if ($currpass !== NULL && $validatePassword['error'] == 1) {
             $this->addAttempt();
             $return['message'] = $validatePassword['message'];
 
@@ -1164,7 +1164,7 @@ class Auth
             return $return;
         }
 
-        if (!password_verify($currpass, $user['password'])) {
+        if ($currpass !== NULL && !password_verify($currpass, $user['password'])) {
             $this->addAttempt();
             $return['message'] = $this->lang["password_incorrect"];
 


### PR DESCRIPTION
Good afternoon,

This PR makes changing a user's password possible without the current password parameter being mandatory. I needed this because administrators of my application needed to be able to do a forced password reset on a specific user, without having to send the user a password recovery email.