### PR TITLE
Fixed self-signed mail server certificates.

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -791,7 +791,7 @@ class Auth
         if ($sendmail === true) {
             // Check configuration for SMTP parameters
             $mail = new PHPMailer;
-			$mail->CharSet = $this->config->mail_charset;
+            $mail->CharSet = $this->config->mail_charset;            
             if ($this->config->smtp) {
                 $mail->isSMTP();
                 $mail->Host = $this->config->smtp_host;
@@ -805,6 +805,12 @@ class Auth
                 if (!is_null($this->config->smtp_security)) {
                     $mail->SMTPSecure = $this->config->smtp_security;
                 }
+            }
+
+            if ( $this->config->smtp_ssl_context ) 
+            {
+                // smtp_ssl_context must be array.
+                $mail->SMTPOptions = array( 'ssl' => $this->config->smtp_ssl_context );
             }
 
             $mail->From = $this->config->site_email;

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=5.4.0",
-		"phpmailer/phpmailer": "^5.2",
+		"phpmailer/phpmailer": "^6.0",
 		"bjeavons/zxcvbn-php": "*"
 	},
 	"autoload": {


### PR DESCRIPTION
Added the ability to pass an array to the phpmailer ssl context via an array in `config->smtp_ssl_context`. This is needed when dealing with mail servers that use self-signed certificates for `tls` and `ssl` connections. Works with [php ssl context options](http://php.net/manual/en/context.ssl.php).

Example config:
```php
$config->smtp_ssl_context = [
   'verify_peer' => false,
   'allow_self_signed' => true
];
```