### PR TITLE
Fix fatal error when using Composer

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -3,6 +3,10 @@
 namespace PHPAuth;
 
 use ZxcvbnPhp\Zxcvbn;
+
+/* Composer will change: use PHPMailer; to: use PHPMailer\PHPMailer\PHPMailer; which causes Fatal errors with PHPAuth.
+Revert it back to: use PHPMailer;
+*/
 use PHPMailer;
 
 /**


### PR DESCRIPTION
First of all, strange that no one can report Issues. Please enable it.

I'm trying to setup PHPAuth using Composer, but I receive the following error out-of-the-box:
`PHP Fatal error: Uncaught Error: Class 'PHPMailer\PHPMailer\PHPMailer' not found in C:\Users\X\vendor\phpauth\phpauth\Auth.php:794`

So I checked out Auth.php and it seems that Composer changes `use PHPMailer;` to `use PHPMailer\PHPMailer\PHPMailer;` which is probably incorrect. So I reverted this change back to `use PHPMailer;` and the issue disappeared.

I'm not an expert in Composer, so there is probably an issue, or am I missing something?

Thanks