### PR TITLE
Changed parameter order of config to maintain backwards compatability

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -25,11 +25,11 @@ class Config
      * in any case, 4th argument defines site language as locale code
      *
      * @param \PDO $dbh
+	 * @param string $config_source -- declare source of config - table name, filepath or data-array
      * @param string $config_type -- default empty (means config in SQL table phpauth_config), possible values: 'sql', 'ini', 'array'
-     * @param string $config_source -- declare source of config - table name, filepath or data-array
      * @param string $config_site_language -- declare site language, empty value means 'en_GB'
      */
-    public function __construct(\PDO $dbh, $config_type = '', $config_source = '', $config_site_language = '')
+    public function __construct(\PDO $dbh,  $config_source = '', $config_type = '', $config_site_language = '')
     {
         if (version_compare(phpversion(), '5.6.0', '<')) {
             die('PHPAuth: PHP 5.6.0+ required for PHPAuth engine!');

--- a/Config.php
+++ b/Config.php
@@ -25,7 +25,7 @@ class Config
      * in any case, 4th argument defines site language as locale code
      *
      * @param \PDO $dbh
-	 * @param string $config_source -- declare source of config - table name, filepath or data-array
+     * @param string $config_source -- declare source of config - table name, filepath or data-array
      * @param string $config_type -- default empty (means config in SQL table phpauth_config), possible values: 'sql', 'ini', 'array'
      * @param string $config_site_language -- declare site language, empty value means 'en_GB'
      */


### PR DESCRIPTION
Between version 1.1.1 and 1.1.2 the capability to pass the table name for the PHPAuth config to constructor has been moved in the parameter order, causing a breaking error for anyone who used this functionality.

While the fix is mostly trivial it would be good to maintain backwards compatibility, especially in patch versions.
