### PR TITLE
Updated config with the correct translation table name

### DIFF
--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -41,7 +41,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('table_requests',  'phpauth_
 INSERT INTO phpauth_config (setting, value) VALUES ('table_sessions',  'phpauth_sessions');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_users', 'phpauth_users');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_emails_banned', 'phpauth_emails_banned');
-INSERT INTO phpauth_config (setting, value) VALUES ('table_translations', 'phpauth_translations'),
+INSERT INTO phpauth_config (setting, value) VALUES ('table_translations', 'phpauth_translation_dictionary'),
 INSERT INTO phpauth_config (setting, value) VALUES ('verify_email_max_length', '100');
 INSERT INTO phpauth_config (setting, value) VALUES ('verify_email_min_length', '5');
 INSERT INTO phpauth_config (setting, value) VALUES ('verify_email_use_banlist',  '1');

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -45,7 +45,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
 ('table_emails_banned', 'phpauth_emails_banned'),
-('table_translations', 'phpauth_translations')
+('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
 ('verify_email_min_length', '5'),
 ('verify_email_use_banlist',  '1'),

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -52,7 +52,7 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('table_sessions',  'phpauth_sessions'),
   ('table_users', 'phpauth_users'),
   ('table_emails_banned', 'phpauth_emails_banned'),
-  ('table_translations', 'phpauth_translations'),
+  ('table_translations', 'phpauth_translation_dictionary'),
   ('verify_email_max_length', '100'),
   ('verify_email_min_length', '5'),
   ('verify_email_use_banlist',  '1'),

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -45,7 +45,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
 ('table_emails_banned', 'phpauth_emails_banned'),
-('table_translations', 'phpauth_translations'),
+('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
 ('verify_email_min_length', '5'),
 ('verify_email_use_banlist',  '1'),


### PR DESCRIPTION
If you choose to use the sql translation source it doesn't work. The phpauth_config contains value "phpauth_translations" when in fact it should be "phpauth_translation_dictionary".