### PR TITLE
Missing translation for  account_not_found

### DIFF
--- a/languages/en_GB.php
+++ b/languages/en_GB.php
@@ -69,5 +69,6 @@ $lang['email_reset_altbody'] = 'Hello, ' . "\n\n" . 'To reset your password plea
 
 $lang['account_deleted'] = "Account deleted successfully.";
 $lang['function_disabled'] = "This function has been disabled.";
+$lang['account_not_found'] = "No account found with that email address";
 
 return $lang;


### PR DESCRIPTION
Translation for account_not_found
Auth.php
Method public function login  
...
      if (!$uid) {
            $this->addAttempt();
            $return['message'] = $this->__lang("account_not_found");

            return $return;
        }