### PR TITLE
Fix #379 - Add cron method to cleanup expired sessions, requests and attempts

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -1847,5 +1847,39 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         return $query->fetch(\PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Deletes expired attempts from the database
+     */
+    private function deleteExpiredAttempts() {
+        $this->dbh->exec("
+            DELETE FROM {$this->config->table_attempts} WHERE NOW() > expiredate
+        ");
+    }
 
+    /**
+     * Deletes expired sessions from the database
+     */
+    private function deleteExpiredSessions() {
+        $this->dbh->exec("
+            DELETE FROM {$this->config->table_sessions} WHERE NOW() > expiredate
+        ");
+    }
+
+    /**
+     * Deletes expired requests from the database
+     */
+    private function deleteExpiredRequests() {
+        $this->dbh->exec("
+            DELETE FROM {$this->config->table_requests} WHERE NOW() > expire
+        ");
+    }
+
+    /**
+     * Daily cron job to remove expired data from the database
+     */
+    public function cron() {
+        $this->deleteExpiredAttempts();
+        $this->deleteExpiredSessions();
+        $this->deleteExpiredRequests();
+    }
 }


### PR DESCRIPTION
This PR adds a new public method `cron()`, aswell as three private methods:
* `deleteExpiredAttempts()`
* `deleteExpiredRequests()`
* `deleteExpiredSessions()`

The idea is to use the public method to frequently cleanup the database, here's an example callable script:

```php
<?php

require_once("vendor/autoload.php");

$dbh = new PDO("mysql:host=localhost;dbname=phpauth_db", "username", "password");

$config = new PHPAuth\Config($dbh);
$auth   = new PHPAuth\Auth($dbh, $config);

$auth->cron();
```