### PR TITLE
use device_id instead of ip for authentication

### DIFF
--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -80,6 +80,7 @@ CREATE TABLE phpauth_sessions (
   hash varchar(40) NOT NULL,
   expiredate DATETIME YEAR TO SECOND,
   ip varchar(39) NOT NULL,
+  device_id varchar(36) DEFAULT NULL,
   agent varchar(200) NOT NULL,
   cookie_crc char(40) NOT NULL,
   PRIMARY KEY (id)

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -84,6 +84,7 @@ CREATE TABLE phpauth_sessions (
   hash character varying(40) NOT NULL,
   expiredate datetime2 NOT NULL,
   ip character varying(39) NOT NULL,
+  device_id character varying(36) DEFAULT NULL,
   agent character varying(200) NOT NULL,
   cookie_crc character (40) NOT NULL,
   PRIMARY KEY (id)

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -101,6 +101,7 @@ CREATE TABLE `phpauth_sessions` (
   `hash` char(40) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL,
   `expiredate` datetime NOT NULL,
   `ip` varchar(39) NOT NULL,
+  `device_id` varchar(36) DEFAULT NULL,
   `agent` varchar(200) NOT NULL,
   `cookie_crc` char(40) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL,
   PRIMARY KEY (`id`)

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -86,6 +86,7 @@ CREATE TABLE phpauth_sessions (
   hash character (40) NOT NULL,
   expiredate timestamp without time zone NOT NULL,
   ip character varying(39) NOT NULL,
+  device_id varchar varying(36) DEFAULT NULL,
   agent character varying(200) NOT NULL,
   cookie_crc character (40) NOT NULL,
   PRIMARY KEY (id)


### PR DESCRIPTION
i have users who use an app on smartphone; but a problem is, that the ip of the phone changes very often (using different wifi's, mobile data and so on).

i also have to call checkSession manually, because the isLogged function uses the getCurrentSessionHash function, which reads a cookie. we should also improve having a choice **to choose from where the hash get's read from**, not only cookie.

the device_id is a v4 uuid - **i added it in the mysql def ONLY**.

now i want to hear your opinion - maybe there is improvement on this?

