### PR TITLE
Administrative status, automatic password expiration, and json storage.

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -249,7 +249,15 @@ class Config
 
         return false;
     }
-
+    
+    /**
+      * Config::__isset()
+      * @param $mixed setting
+      * @return false if empty or not set
+    */
+    public function __isset($content) {
+        return isset($this->config[$content]) && !empty($this->config[$content]);
+    }
     /**
      * Config::override()
      *

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The database table `config` contains multiple parameters allowing you to configu
 * `cookie_remember` : the time that a user will remain logged in for when ticking "remember me" on login. Must respect PHP's [strtotime](http://php.net/manual/en/function.strtotime.php) format.
 * `cookie_forget` : the time a user will remain logged in when not ticking "remember me" on login.  Must respect PHP's [strtotime](http://php.net/manual/en/function.strtotime.php) format.
 * `cookie_renew` : the maximum time difference between session expiration and last page load before allowing the session to be renewed. Must respect PHP`s [strtotime](http://php.net/manual/en/function.strtotime.php) format.
+* `days_for_automatic_password_expiration` : Automatic days for expiration of the password, it adds days to time() when creation or password change, for non expiring password, set this value to 0, as global parameter, or `days2expire` to configure per user basis at table `phpauth_users`
 * `allow_concurrent_sessions` : Allow a user to have multiple active sessions (boolean). If false (default), logging in will end any existing sessions.
 * `bcrypt_cost` : the algorithmic cost of the bcrypt hashing function, can be changed based on hardware capabilities
 * `smtp` : `0` to use sendmail for emails, `1` to use SMTP
@@ -137,6 +138,7 @@ The database table `config` contains multiple parameters allowing you to configu
 * `table_requests` : name of the table with all requests (default is 'phpauth_requests')
 * `table_sessions` : name of the table with all sessions (default is 'phpauth_sessions')
 * `table_users` : name of the table with all users (default is 'phpauth_users')
+* `table_params` : name of the table where the description of the json parameters are configured, to be stored in `phpauth_users.params`, if you want to replicate old behavior leave empty, default is `phpauth_params`
 * `table_emails_banned` : name of the table with all banned email domains (default is 'phpauth_emails_banned')
 * `recaptcha_enabled`: 1 for Google reCaptcha enabled, 0 - disabled (default)
 * `recaptcha_site_key`: string, contains public reCaptcha key (for javascripts)
@@ -353,7 +355,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/hajro92"><img src="https://avatars0.githubusercontent.com/u/15570002?v=4" width="100px;" alt=""/><br /><sub><b>Hajrudin</b></sub></a><br /><a href="#translation-hajro92" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/Conver"><img src="https://avatars1.githubusercontent.com/u/6231022?v=4" width="100px;" alt=""/><br /><sub><b>conver</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=conver" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/louis123562"><img src="https://avatars1.githubusercontent.com/u/36068395?v=4" width="100px;" alt=""/><br /><sub><b>louis123562</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=louis123562" title="Documentation">📖</a></td>
-    <td align="center"><a href="http://www.ifscore.info"><img src="https://avatars1.githubusercontent.com/u/4574233?v=4" width="100px;" alt=""/><br /><sub><b>ANDRES TELLO</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=Criptos" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.ifscore.info"><img src="https://avatars1.githubusercontent.com/u/4574233?v=4" width="100px;" alt=""/><br /><sub><b>Criptos</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=Criptos" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -17,6 +17,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('cookie_path', '/');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_remember', '+1 month');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_secure', '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_renew', '+5 minutes');
+INSERT INTO phpauth_config (setting, value) VALUES ('days_for_automatic_password_expiration', '30'); 
 INSERT INTO phpauth_config (setting, value) VALUES ('allow_concurrent_sessions', FALSE);
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_activation',  '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_reset', '0');
@@ -43,6 +44,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('table_attempts',  'phpauth_
 INSERT INTO phpauth_config (setting, value) VALUES ('table_requests',  'phpauth_requests');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_sessions',  'phpauth_sessions');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_users', 'phpauth_users');
+INSERT INTO phpauth_config (setting, value) VALUES ('table_params', 'phpauth_params');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_emails_banned', 'phpauth_emails_banned');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_translations', 'phpauth_translation_dictionary'),
 INSERT INTO phpauth_config (setting, value) VALUES ('verify_email_max_length', '100');
@@ -91,9 +93,25 @@ CREATE TABLE phpauth_users (
   email varchar(100) DEFAULT NULL,
   password varchar(255) DEFAULT NULL,
   isactive smallint DEFAULT 0 NOT NULL,
+  expiration DATETIME YEAR TO SECOND,
+  days2expire smallint DEFAULT 0  NOT NULL,
+  params JSON  DEFAULT '{}', 
+  status varchar(100) DEFAULT NULL,
+  statuschange DATETIME YEAR TO SECOND,  
   dt DATETIME YEAR TO SECOND DEFAULT CURRENT YEAR TO SECOND,
   PRIMARY KEY (id)
 );
+
+
+DROP TABLE phpauth_params;
+CREATE TABLE phpauth_params (
+  json_key varchar(100) DEFAULT '',
+  name varchar(100) DEFAULT '', 
+  required varchar(2) DEFAULT 'y', 
+  description VARCHAR(255) DEFAULT '',
+  filter VARCHAR(255) DEFAULT 'NONE',
+  PRIMARY KEY (json_key)
+)
 
 DROP TABLE phpauth_emails_banned;
 CREATE TABLE phpauth_emails_banned (

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -20,6 +20,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('cookie_remember', '+1 month'),
 ('cookie_secure', '0'),
 ('cookie_renew', '+5 minutes'),
+('days_for_automatic_password_expiration', '30'), 
 ('allow_concurrent_sessions', FALSE),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
@@ -47,6 +48,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_requests',  'phpauth_requests'),
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
+('table_params', 'phpauth_params'),
 ('table_emails_banned', 'phpauth_emails_banned'),
 ('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
@@ -95,8 +97,24 @@ CREATE TABLE phpauth_users (
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
+  expiration datetime2 NOT NULL DEFAULT 0,
+  days2expire smallint UNSIGNED NOT NULL DEFAULT 0,
+  params nvarchar(max) NOT NULL DEFAULT '{}', 
+  status character varying(20) DEFAULT NULL,
+  statuschange datetime2 NOT NULL DEFAULT 0,  
   dt datetime2 NOT NULL DEFAULT GETDATE(),
   PRIMARY KEY (id)
+);
+
+
+DROP TABLE IF EXISTS `phpauth_params`;
+CREATE TABLE `phpauth_params` (
+  `json_key` character varying(100) DEFAULT '',
+  `name` character varying(100) DEFAULT '', 
+  `required` character varying(2) DEFAULT 'y', 
+  `description` character varying(255) DEFAULT '',
+  `filter` character varying(100) DEAULT 'NONE',
+  PRIMARY KEY (`json_key`)
 );
 
 DROP TABLE IF EXISTS phpauth_emails_banned;

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -27,6 +27,7 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('cookie_remember', '+1 month'),
   ('cookie_secure', '0'),
   ('cookie_renew', '+5 minutes'),
+  ('days_for_automatic_password_expiration', '30'), 
   ('allow_concurrent_sessions', FALSE),
   ('emailmessage_suppress_activation',  '0'),
   ('emailmessage_suppress_reset', '0'),
@@ -54,6 +55,7 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('table_requests',  'phpauth_requests'),
   ('table_sessions',  'phpauth_sessions'),
   ('table_users', 'phpauth_users'),
+  ('table_params', 'phpauth_params'),
   ('table_emails_banned', 'phpauth_emails_banned'),
   ('table_translations', 'phpauth_translation_dictionary'),
   ('verify_email_max_length', '100'),
@@ -114,9 +116,28 @@ CREATE TABLE `phpauth_users` (
   `email` varchar(100) DEFAULT NULL,
   `password` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
   `isactive` tinyint(1) NOT NULL DEFAULT '0',
+  `expiration` timestamp NOT NULL DEFAULT 0,
+  `days2expire` int(3) UNSIGNED NOT NULL DEFAULT 0,
+  `params` JSON NOT NULL DEFAULT '{}', 
+  `status` enum ('enabled', 'disabled', 'deleted') DEFAULT 'enabled', 
+  `statuschange` timestamp NOT NULL DEFAULT 0,
   `dt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `email` (`email`)
+  KEY `email` (`email`), 
+  KEY `expiration` (`expiration`),
+  KEY `exporationstatus` (`expiration`, `status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- User Parameters Table
+
+DROP TABLE IF EXISTS `phpauth_params`;
+CREATE TABLE `phpauth_params` (
+  `json_key` varchar(100) DEFAULT '',
+  `name` varchar(100) DEFAULT '', 
+  `required` enum('y', 'n') DEFAULT 'y', 
+  `description` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
+  `filter` enum('NONE', 'FILTER_SANITIZE_EMAIL', 'FILTER_SANITIZE_ENCODED', 'FILTER_SANITIZE_NUMBER_FLOAT', 'FILTER_SANITIZE_NUMBER_INT', 'FILTER_SANITIZE_SPECIAL_CHARS', 'FILTER_SANITIZE_STRING', 'FILTER_SANITIZE_URL') default 'NONE',  
+  PRIMARY KEY (`json_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Banned emails reference

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -20,6 +20,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('cookie_remember', '+1 month'),
 ('cookie_secure', '0'),
 ('cookie_renew', '+5 minutes'),
+('days_for_automatic_password_expiration', '30'), 
 ('allow_concurrent_sessions', FALSE),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
@@ -47,6 +48,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_requests',  'phpauth_requests'),
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
+('table_params', 'phpauth_params'),
 ('table_emails_banned', 'phpauth_emails_banned'),
 ('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
@@ -97,6 +99,11 @@ CREATE TABLE phpauth_users (
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
+  expiration timestamp without time zone NOT NULL,
+  days2expire integer UNSIGNED NOT NULL DEFAULT 0,
+  params JSON NOT NULL DEFAULT '{}', 
+  status character varying(10), 
+  statuschange timestamp without time zone NOT NULL,  
   dt timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 );


### PR DESCRIPTION
# Configuration directives
`days_for_automatic_password_expiration` number of default days before password expiration, if set  to 0 password globally doesn't expire.
`phpauth_params` table to storage json structure of field params, if empty use old behavior requiring  modifying the table to accept params. 

# Table changes to `phpauth_users`
`expiration` datetime: date after which the password is considered as expired.
`days2expire` int(3):  per user configuration, when used is created by default uses configuration option of `days_for_automatic_password_expiration` if set to 0, password does't expire. This is a per user configuration.
`params` JSON: Storage of the fields described by `phpauth_params`, as a json_object.
`status` enum ('enabled', 'disabled', 'deleted'): Administrative status of the account
`statuschange` timestamp: date of the last chage of status 

# New Table `phpauth_params` 
```
DROP TABLE IF EXISTS `phpauth_params`;
CREATE TABLE `phpauth_params` (
  `json_key` varchar(100) DEFAULT '',
  `name` varchar(100) DEFAULT '', 
  `required` enum('y', 'n') DEFAULT 'y', 
  `description` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
  `filter` enum('NONE', 'FILTER_SANITIZE_EMAIL', 'FILTER_SANITIZE_ENCODED', 'FILTER_SANITIZE_NUMBER_FLOAT', 'FILTER_SANITIZE_NUMBER_INT', 'FILTER_SANITIZE_SPECIAL_CHARS', 'FILTER_SANITIZE_STRING', 'FILTER_SANITIZE_URL') default 'NONE',  
  PRIMARY KEY (`json_key`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

# Administrative status management. 
Use case: Management required fine gran control over user accounts. 
This is a flag, if an account is disabled, when the  user tries to login a disable account message is generated. 
If the user deletes the account, the status delete is enabled, instead of deleting  the account. The `purgeUser` function is created to remove the user from the database. 

* disable($email) to disable the account by email 
* enable($email) to enable the account by email 
* deleteUser($uid, $password, $captcha_response = null)  set the account status to deleted 
* deleteUserForced($uid) set the account status to deleted
* purgeUser($uid) remove the user from the database 
* verifyStatus($email)  protected function to verify the status, no error on enabled status, error on disabled and deleted
 
# Automatic passsword expiration. 
Use case: Passwords are required to expire automatically. 
Use case: Expiration days is a parameter settable per user. 

This functionally can be disabled globally if configuration value `days_for_automatic_password_expiration` is set to 0. 
When the user is created the configuration value `days_for_automatic_password_expiration` is propagated to the `phpauth_user.days2expire` and the password expiration date is set to now() + days2expire days. 

If the `phpauth_user.days2expire` is set to 0, the password doesn't expire. 

* updateDays2Expire($uid, $days2expire, $doExpiration=false) set the days2expire for the user $uid, if $doExpiration is set to true, the expiration date is also updated, using as reference now() 
* updateExpiration($uid, $expiration) set an arbitrary expiration date, the format is YYYY-MM-DD, accepts date in the past to force expiration. 

# Json storage of params.
Use case: PHPAuth must be deployed as dynamic microservice authentication. 
Use case: PHPAuth should be used by everyone, avoiding alteration of system tables. 
Disclaimer: This is not a replacement for a separate table to hold all the user details, on behalf security, the user credentials and the user details should live in separate server limit the data leakage, the json data should be the minimal data to identify the user. 

Parameters can be added to `table_params` using the function addParam(), the arguments are:
* addParam($key=null, $name=null, $required=null, $description=null, $filter="NONE")
  *  $key the name of the key at the json object, cannot be empty and will be sanitized and lowerized
  *  $name human name of the variable, suitable for UI, if empty, key will be used instead 
  *  $required y/n, default y,  
  *  $description description of the filed, human redeable, suitable for UI, can be empty
  *  $filter, filter_var php to be applied, options: NONE,  FILTER_SANITIZE_EMAIL, FILTER_SANITIZE_ENCODED, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_SANITIZE_NUMBER_INT, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_SANITIZE_STRING, FILTER_SANITIZE_URL, default NONE 
* removeParam($key=null) removes the parameter from the table `table_params`
* buildParams() prepares an array as skeleton used to validate the user params. 
* appyFilterParams($params) match the params to the array built by `buildParams()`, if a parameter is set as required but not present, an error is throw and no data is updated. 

**To disable this behavior, set the configuration option `table_params` to '' (empty)**

# System error added or updated
(addParam) Key null or empty #17 
(addParam) filter not valir #18
(addParam) Key select query failed #19
(addParam) Duplicated key #20
(addParam) Inser failed to table_param #21
(login)    Account is  deleted my administration #22
(deleteUser) Failed to delete user from user table #05
(disable) Failed to update table #23
(enable)  Failer to update table #24

# Config.php & emtpy 
Config.php uses the magic method of __set, so to test for emtpy, more magic is needed, so magic function __isset is defined to enable the correct functionality of isset and empty. 
Ref: https://www.tutorialdocs.com/article/16-php-magic-methods.html



