### PR TITLE
Automatic exporation for password, JSON storage and JWT Token

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -5,6 +5,8 @@ namespace PHPAuth;
 use ZxcvbnPhp\Zxcvbn;
 use PHPMailer\PHPMailer\PHPMailer;
 use ReCaptcha\ReCaptcha;
+use \Firebase\JWT\JWT; 
+
 
 /*require_once 'AuthInterface.php';*/
 

--- a/Auth.php
+++ b/Auth.php
@@ -5,7 +5,7 @@ namespace PHPAuth;
 use ZxcvbnPhp\Zxcvbn;
 use PHPMailer\PHPMailer\PHPMailer;
 use ReCaptcha\ReCaptcha;
-use \Firebase\JWT\JWT; 
+use \Firebase\JWT\JWT;
 
 
 /*require_once 'AuthInterface.php';*/
@@ -51,15 +51,15 @@ class Auth/* implements AuthInterface*/
      * @var \stdClass $recaptcha_config
      */
     protected $recaptcha_config = [];
-    
+
     /**
      * @var string private key used for jtw 
-    */
+     */
     protected $private = "";
-    
+
     /**
-      * @var string secret public key if RS256 is used
-    */
+     * @var string secret public key if RS256 is used
+     */
     protected $public = "";
 
     /**
@@ -81,9 +81,9 @@ class Auth/* implements AuthInterface*/
         $this->messages_dictionary = $this->config->dictionary;
 
         date_default_timezone_set($this->config->site_timezone);
-        $this->isAuthenticated= false; 
-        $this->private = false; 
-        $this->public =  false; 
+        $this->isAuthenticated = false;
+        $this->private = false;
+        $this->public =  false;
     }
 
     /**
@@ -98,6 +98,7 @@ class Auth/* implements AuthInterface*/
     public function login($email, $password, $remember = 0, $captcha_response = null)
     {
         $return['error'] = true;
+        $return['password_expired'] = false;
 
         $block_status = $this->isBlocked();
 
@@ -112,17 +113,17 @@ class Auth/* implements AuthInterface*/
             $return['message'] = $this->__lang("user_blocked");
             return $return;
         }
-        
+
 
         $status = $this->verifyStatus($email);
         $validateEmail = $this->validateEmail($email);
         $validatePassword = $this->validatePassword($password);
-        
-        if($status['error'] == 1) { 
-            $return['message'] = $status['message']; 
-            
+
+        if ($status['error'] == 1) {
+            $return['message'] = $status['message'];
+
             return $return;
-        }  elseif ($validateEmail['error'] == 1) {
+        } elseif ($validateEmail['error'] == 1) {
             $this->addAttempt();
             $return['message'] = $validateEmail['message']; // ?? $this->__lang("account_email_invalid");
 
@@ -149,10 +150,11 @@ class Auth/* implements AuthInterface*/
         }
 
         $user = $this->getBaseUser($uid);
-        
-        if($user['days2expire'] > 0 && time() > strtotime($user['expiration'])) {
+
+        if ($user['days2expire'] > 0 && time() > strtotime($user['expiration'])) {
             $this->addAttempt();
             $return['message'] = $this->__lang("password_expired");
+            $return['password_expired'] = true;
 
             return $return;
         }
@@ -184,12 +186,12 @@ class Auth/* implements AuthInterface*/
 
         $return['hash'] = $sessiondata['hash'];
         $return['expire'] = $sessiondata['expire'];
-		
-		$return['cookie_name'] = $this->config->cookie_name;
+
+        $return['cookie_name'] = $this->config->cookie_name;
 
         return $return;
     }
-    
+
     /**
      * Logs a user in and genereate JTW token
      * @param string $email
@@ -199,44 +201,44 @@ class Auth/* implements AuthInterface*/
      * @return array with $result 
      */
     //@todo: => loginUser
-    public function appLogin($email, $password, $remember = 0, $captcha_response = null, $callback=false, $iss=null, $aud=null)
+    public function appLogin($email, $password, $remember = 0, $captcha_response = null, $callback = false, $iss = null, $aud = null)
     {
-        $result['error']=true; 
-        $auth=$this->login($email, $password, $remember, $captcha_response); 
-        if($auth['error']){
-            return $auth; 
+        $result['error'] = true;
+        $auth = $this->login($email, $password, $remember, $captcha_response);
+        if ($auth['error']) {
+            return $auth;
         }
-        
-        if(is_null($iss)){
-            $iss=$this->config->default_jwt_iss; 
+
+        if (is_null($iss)) {
+            $iss = $this->config->default_jwt_iss;
         }
-        
-        if(is_null($aud)){
-            $aud=$this->config->default_jwt_aud; 
+
+        if (is_null($aud)) {
+            $aud = $this->config->default_jwt_aud;
         }
-        
-        $jwt=$this->generateJWT($iss, $aud, $remember, $auth['hash'], $callback); 
-        if(!$jwt){
-            $result['message']=$this->__lang("token_not_created"); 
-            return $result; 
+
+        $jwt = $this->generateJWT($iss, $aud, $remember, $auth['hash'], $callback);
+        if (!$jwt) {
+            $result['message'] = $this->__lang("token_not_created");
+            return $result;
         }
-        
-        $result['error']=false; 
-        $result['jwt']=$jwt; 
+
+        $result['error'] = false;
+        $result['jwt'] = $jwt;
         return $result;
     }
-    
+
 
     /**
-    * Creates a new user, adds them to database
-    * @param string $email
-    * @param string $password
-    * @param string $repeatpassword
-    * @param array  $params
-    * @param string $captcha_response = null
-    * @param bool $use_email_activation = null
-    * @return array $return
-    */
+     * Creates a new user, adds them to database
+     * @param string $email
+     * @param string $password
+     * @param string $repeatpassword
+     * @param array  $params
+     * @param string $captcha_response = null
+     * @param bool $use_email_activation = null
+     * @return array $return
+     */
     //@todo: => registerUserAccount
     public function register($email, $password, $repeatpassword, $params = [], $captcha_response = null, $use_email_activation = null)
     {
@@ -272,12 +274,12 @@ class Auth/* implements AuthInterface*/
             return $return;
         }
         // passsword not the same as email
-        if(strcmp($email, $password)==0){
+        if (strcmp($email, $password) == 0) {
             $return['message'] = $this->__lang('same_as_email');
 
             return $return;
         }
-        
+
 
         // Validate password
         $validatePassword = $this->validatePassword($password);
@@ -314,17 +316,17 @@ class Auth/* implements AuthInterface*/
         $return['error'] = false;
         $return['message'] =
             ($use_email_activation == true
-            ? $this->__lang("register_success")
-            : $this->__lang('register_success_emailmessage_suppressed') );
+                ? $this->__lang("register_success")
+                : $this->__lang('register_success_emailmessage_suppressed'));
 
         return $return;
     }
 
     /**
-    * Activates a user's account
-    * @param string $activate_token
-    * @return array $return
-    */
+     * Activates a user's account
+     * @param string $activate_token
+     * @return array $return
+     */
     public function activate($activate_token) //@todo: rename to 'activateUserAccount'
     {
         $return['error'] = true;
@@ -347,14 +349,14 @@ class Auth/* implements AuthInterface*/
         // NOW is no any way to determine, is this token used for activation or not?
 
         $request_result = $this->getRequest($activate_token, "activation");
-        
+
 
         if ($request_result['error']) {
             $return['message'] = $request_result['message'];
 
             return $return;
         }
-        
+
 
         if ($this->getBaseUser($request_result['uid'])['isactive'] == 1) {
             $this->addAttempt();
@@ -363,16 +365,16 @@ class Auth/* implements AuthInterface*/
 
             return $return;
         }
-        
-        $status=$this->verifyStatusbyid($request_result['uid']);
-        
-        if($status['error']){
-            $return['message']= $status['message']; 
-            
-            return $return; 
+
+        $status = $this->verifyStatusbyid($request_result['uid']);
+
+        if ($status['error']) {
+            $return['message'] = $status['message'];
+
+            return $return;
         }
-        
-        
+
+
 
         $query = "UPDATE {$this->config->table_users} SET isactive = :isactive WHERE id = :id";
         $query_prepared = $this->dbh->prepare($query);
@@ -446,10 +448,10 @@ class Auth/* implements AuthInterface*/
     }
 
     /**
-    * Logs out the session, identified by hash
-    * @param string $hash
-    * @return boolean
-    */
+     * Logs out the session, identified by hash
+     * @param string $hash
+     * @return boolean
+     */
     public function logout($hash)
     {
         if (strlen($hash) != self::HASH_LENGTH) {
@@ -463,10 +465,10 @@ class Auth/* implements AuthInterface*/
     }
 
     /**
-    * Logs out of all sessions for specified uid
-    * @param int $uid
-    * @return boolean
-    */
+     * Logs out of all sessions for specified uid
+     * @param int $uid
+     * @return boolean
+     */
     public function logoutAll($uid)
     {
         $this->isAuthenticated = false;
@@ -474,23 +476,23 @@ class Auth/* implements AuthInterface*/
 
         return $this->deleteExistingSessions($uid);
     }
-    
+
 
     /**
-    * Hashes provided password with Bcrypt
-    * @param string $password
-    * @return string
-    */
+     * Hashes provided password with Bcrypt
+     * @param string $password
+     * @return string
+     */
     public function getHash($password)
     {
         return password_hash($password, PASSWORD_BCRYPT, ['cost' => $this->config->bcrypt_cost]);
     }
 
     /**
-    * Gets UID for a given email address, return int
-    * @param string $email
-    * @return int $uid
-    */
+     * Gets UID for a given email address, return int
+     * @param string $email
+     * @return int $uid
+     */
     public function getUID($email)
     {
         $query = "SELECT id FROM {$this->config->table_users} WHERE email = :email";
@@ -505,11 +507,11 @@ class Auth/* implements AuthInterface*/
     }
 
     /**
-    * Creates a session for a specified user id
-    * @param int $uid
-    * @param boolean $remember
-    * @return array $data
-    */
+     * Creates a session for a specified user id
+     * @param int $uid
+     * @param boolean $remember
+     * @return array $data
+     */
     protected function addSession($uid, $remember)
     {
         $ip = $this->getIp();
@@ -544,10 +546,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         $query_params = [
             'uid'       => $uid,
             'hash'      => $data['hash'],
-            'expiredate'=> date("Y-m-d H:i:s", $data['expire']),
+            'expiredate' => date("Y-m-d H:i:s", $data['expire']),
             'ip'        => $ip,
             'agent'     => $agent,
-            'cookie_crc'=> $data['cookie_crc']
+            'cookie_crc' => $data['cookie_crc']
         ];
 
         if (!$query_prepared->execute($query_params)) {
@@ -563,10 +565,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     //@todo: delete cookie at deleteSession
 
     /**
-    * Removes all existing sessions for a given UID wher phpauth_users.id=UID
-    * @param int $uid
-    * @return boolean
-    */
+     * Removes all existing sessions for a given UID wher phpauth_users.id=UID
+     * @param int $uid
+     * @return boolean
+     */
     protected function deleteExistingSessions($uid)
     {
         $query = "DELETE FROM {$this->config->table_sessions} WHERE uid = :uid";
@@ -577,10 +579,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Removes a session based on hash
-    * @param string $hash
-    * @return boolean
-    */
+     * Removes a session based on hash
+     * @param string $hash
+     * @return boolean
+     */
 
     protected function deleteSession($hash)
     {
@@ -591,15 +593,15 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Function to check if a session is valid
-    * @param string $hash
-    * @param bool $jwt check if we are verifying on behalf a jwt token
-    * @return boolean
-    */
-    public function checkSession($hash, $jwt=false)
+     * Function to check if a session is valid
+     * @param string $hash
+     * @param bool $jwt check if we are verifying on behalf a jwt token
+     * @return boolean
+     */
+    public function checkSession($hash, $jwt = false)
     {
-    
-       
+
+
         $ip = $this->getIp();
         $block_status = $this->isBlocked();
         if ($block_status == "block") {
@@ -623,19 +625,19 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         $row = $query_prepared->fetch(\PDO::FETCH_ASSOC);
-        
+
         $uid = $row['uid'];
         $expiredate = strtotime($row['expiredate']);
         $currentdate = strtotime(date("Y-m-d H:i:s"));
         $db_ip = $row['ip'];
         $db_cookie = $row['cookie_crc'];
-        
-        
-        $status=$this->verifyStatusbyid($uid);
-        
-        if($status['error']) {
-            $this->deleteSession($hash); 
-            
+
+
+        $status = $this->verifyStatusbyid($uid);
+
+        if ($status['error']) {
+            $this->deleteSession($hash);
+
             return false;
         }
 
@@ -662,10 +664,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Retrieves the UID associated with a given session hash
-    * @param string $hash
-    * @return int $uid
-    */
+     * Retrieves the UID associated with a given session hash
+     * @param string $hash
+     * @return int $uid
+     */
     public function getSessionUID($hash)
     {
         $query = "SELECT uid FROM {$this->config->table_sessions} WHERE hash = :hash";
@@ -683,10 +685,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Checks if an email is already in use
-    * @param string $email
-    * @return boolean
-    */
+     * Checks if an email is already in use
+     * @param string $email
+     * @return boolean
+     */
     public function isEmailTaken($email)
     {
         $query = "SELECT count(*) FROM {$this->config->table_users} WHERE email = :email";
@@ -701,15 +703,15 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Checks if an email is banned
-    * @param string $email
-    * @return boolean
-    */
+     * Checks if an email is banned
+     * @param string $email
+     * @return boolean
+     */
     public function isEmailBanned($email)
     {
-        try{
+        try {
             $this->dbh->query("SELECT * FROM {$this->config->table_emails_banned} LIMIT 1;");
-        }catch (PDOException $e){
+        } catch (\PDOException $e) {
             return false;
         }
 
@@ -727,19 +729,19 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Adds a new user to database
-    * @param string $email      -- email
-    * @param string $password   -- password
-    * @param array $params      -- additional params
-    * @param boolean $use_email_activation  -- activate email confirm or not
-    * @return array
-    */
+     * Adds a new user to database
+     * @param string $email      -- email
+     * @param string $password   -- password
+     * @param array $params      -- additional params
+     * @param boolean $use_email_activation  -- activate email confirm or not
+     * @return array
+     */
     protected function addUser($email, $password, $params = [], &$use_email_activation)
     {
         $return['error'] = true;
-        
-        $this->dbh->beginTransaction(); 
-        
+
+        $this->dbh->beginTransaction();
+
         $query = "INSERT INTO {$this->config->table_users} (isactive) VALUES (0)";
         $query_prepared = $this->dbh->prepare($query);
 
@@ -755,7 +757,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
             $addRequest = $this->addRequest($uid, $email, "activation", $use_email_activation);
 
             if ($addRequest['error'] == 1) {
-                $this->dbh->rollBack(); 
+                $this->dbh->rollBack();
                 $return['message'] = $addRequest['message'];
                 return $return;
             }
@@ -766,39 +768,40 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         $password = $this->getHash($password);
-        if(empty($this->config->days_for_automatic_password_expiration) || $this->config->days_for_automatic_password_expiration < 1){
-            $days2expire=0; 
-            $expiration="0000-00-00 00:00:00"; 
+        if (empty($this->config->days_for_automatic_password_expiration) || $this->config->days_for_automatic_password_expiration < 1) {
+            $days2expire = 0;
+            $expiration = "0000-00-00 00:00:00";
         } else {
-            $days2expire=$this->config->days_for_automatic_password_expiration; 
-            $expiration=date("Y-m-d H:i:s", strtotime("now +{$this->config->days_for_automatic_password_expiration} days"));
+            $days2expire = $this->config->days_for_automatic_password_expiration;
+            $expiration = date("Y-m-d H:i:s", strtotime("now +{$this->config->days_for_automatic_password_expiration} days"));
         }
-        
-        if(empty($this->config->table_params)){ 
+
+        if (empty($this->config->table_params)) {
             //retain backwards compatibility
-            if (is_array($params)&& count($params) > 0) {
+            if (is_array($params) && count($params) > 0) {
                 $customParamsQueryArray = [];
 
-                foreach($params as $paramKey => $paramValue) {
+                foreach ($params as $paramKey => $paramValue) {
                     $customParamsQueryArray[] = ['value' => $paramKey . ' = ?'];
                 }
 
                 $setParams = ', ' . implode(', ', array_map(function ($entry) {
                     return $entry['value'];
                 }, $customParamsQueryArray));
-            } else { $setParams = ''; }
+            } else {
+                $setParams = '';
+            }
 
             $query = "UPDATE {$this->config->table_users} SET email = ?, password = ?, isactive = ?, days2expire =?, expiration=?, status = 'enabled', statuschange=Now() {$setParams} WHERE id = ?";
             $query_prepared = $this->dbh->prepare($query);
             $bindParams = array_values(array_merge([$email, $password, $isactive, $days2expire, $expiration], $params, [$uid]));
-            
         } else {
-            try { 
-                $json_params=json_encode($this->appyFilterParams($params)); 
-            } catch (\Exception $e){
-                $this->dbh->rollBack(); 
-                $return['message']=$e->getMessage(); 
-                return $return; 
+            try {
+                $json_params = json_encode($this->appyFilterParams($params));
+            } catch (\Exception $e) {
+                $this->dbh->rollBack();
+                $return['message'] = $e->getMessage();
+                return $return;
             }
             $query = "UPDATE {$this->config->table_users} SET email = ?, password = ?, isactive = ?, days2expire = ?, expiration = ?, params = ?, status = 'enabled', statuschange=Now() WHERE id = ?";
             $query_prepared = $this->dbh->prepare($query);
@@ -806,21 +809,21 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         if (!$query_prepared->execute($bindParams)) {
-            $this->dbh->rollBack(); 
+            $this->dbh->rollBack();
             $return['message'] = $this->__lang("system_error") . " #04";
             return $return;
         }
-        $this->dbh->commit(); 
+        $this->dbh->commit();
         $return['uid'] = $uid;
         $return['error'] = false;
         return $return;
     }
 
     /**
-    * Gets basic user data for a given UID and returns an array
-    * @param int $uid
-    * @return array $data
-    */
+     * Gets basic user data for a given UID and returns an array
+     * @param int $uid
+     * @return array $data
+     */
     protected function getBaseUser($uid)
     {
         $query = "SELECT email, password, isactive, days2expire, expiration, status FROM {$this->config->table_users} WHERE id = :id";
@@ -839,11 +842,11 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Gets public user data for a given UID and returns an array, password will be returned if param $withpassword is TRUE
-    * @param int $uid
-    * @param bool|false $withpassword
-    * @return array $data
-    */
+     * Gets public user data for a given UID and returns an array, password will be returned if param $withpassword is TRUE
+     * @param int $uid
+     * @param bool|false $withpassword
+     * @return array $data
+     */
     public function getUser($uid, $withpassword = false)
     {
         $query = "SELECT * FROM {$this->config->table_users} WHERE id = :id";
@@ -861,19 +864,19 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         if (!$withpassword)
             unset($data['password']);
 
-        if(empty($this->config->table_params))
-        $data['params']=json_decode($params); 
+        if (empty($this->config->table_params))
+            $data['params'] = json_decode($params);
         return $data;
     }
 
 
     /**
-    * Allows a user to delete their account
-    * @param int $uid
-    * @param string $password
-    * @param string $captcha_response = null
-    * @return array $return
-    */
+     * Allows a user to delete their account
+     * @param int $uid
+     * @param string $password
+     * @param string $captcha_response = null
+     * @return array $return
+     */
     public function deleteUser($uid, $password, $captcha_response = null)
     {
         $return['error'] = true;
@@ -943,7 +946,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         return $return;
     }
-    
+
     /**
      * Force delete user without password or captcha verification.
      *
@@ -986,12 +989,12 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         return $return;
     }
-    
+
     /** 
-      * Purge user, delete permanently 
-      * @param $uid
-      * @return mixed
-    */
+     * Purge user, delete permanently 
+     * @param $uid
+     * @return mixed
+     */
     public function purgeUser($uid)
     {
         $return['error'] = true;
@@ -1030,10 +1033,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-      * Disable user administratively 
-      * @param $email
-      * @param mixed
-    */
+     * Disable user administratively 
+     * @param $email
+     * @param mixed
+     */
     public function disable($email)
     {
         $return['error'] = true;
@@ -1054,10 +1057,10 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-      * Enable user administratively 
-      * @param $email
-      * @param mixed
-    */
+     * Enable user administratively 
+     * @param $email
+     * @param mixed
+     */
     public function enable($email)
     {
         $return['error'] = true;
@@ -1076,17 +1079,17 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         return $return;
     }
-    
+
     // protected function add
 
     /**
-    * Creates an activation entry and sends email to user
-    * @param int $uid
-    * @param string $email
-    * @param string $type
-    * @param boolean $use_email_activation
-    * @return array
-    */
+     * Creates an activation entry and sends email to user
+     * @param int $uid
+     * @param string $email
+     * @param string $type
+     * @param boolean $use_email_activation
+     * @return array
+     */
     protected function addRequest($uid, $email, $type, &$use_email_activation)
     {
         $return['error'] = true;
@@ -1096,11 +1099,9 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         if ($type == 'activation') {
 
             $dictionary_key__request_exists = 'activation_exists';
-
         } elseif ($type == 'reset') {
 
             $dictionary_key__request_exists = 'reset_exists';
-
         } else {
             $return['message'] = $this->__lang("system_error") . " #08";
 
@@ -1113,12 +1114,12 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         if (false !== $use_email_activation) {
             $use_email_activation = true;
 
-            if ($type == "reset" && !! $this->config->emailmessage_suppress_reset) {
-	            $send_email = false;
+            if ($type == "reset" && !!$this->config->emailmessage_suppress_reset) {
+                $send_email = false;
             }
 
-            if ($type == "activation" && !! $this->config->emailmessage_suppress_activation) {
-	            $send_email = false;
+            if ($type == "activation" && !!$this->config->emailmessage_suppress_activation) {
+                $send_email = false;
             }
         }
 
@@ -1191,11 +1192,11 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Returns request data if key is valid
-    * @param string $key
-    * @param string $type
-    * @return array $return
-    */
+     * Returns request data if key is valid
+     * @param string $key
+     * @param string $type
+     * @return array $return
+     */
     public function getRequest($key, $type)
     {
         $return['error'] = true;
@@ -1206,7 +1207,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         if ($query_prepared->rowCount() === 0) {
             $this->addAttempt();
-            $return['message'] = $this->__lang( $type."key_incorrect" );
+            $return['message'] = $this->__lang($type . "key_incorrect");
 
             return $return;
         }
@@ -1219,7 +1220,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         if ($currentdate > $expiredate) {
             $this->addAttempt();
             $this->deleteRequest($row['id']);
-            $return['message'] = $this->__lang( $type."key_expired" );
+            $return['message'] = $this->__lang($type . "key_expired");
 
             return $return;
         }
@@ -1232,96 +1233,97 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Deletes request from database
-    * @param int $id
-    * @return boolean
-    */
+     * Deletes request from database
+     * @param int $id
+     * @return boolean
+     */
     protected function deleteRequest($id)
     {
         $query = "DELETE FROM {$this->config->table_requests} WHERE id = :id";
         $query_prepared = $this->dbh->prepare($query);
         return $query_prepared->execute(['id' => $id]);
     }
-    
+
     /**
      * Verifies the administrative status 
      * @param int $uid 
      * @return array $return ['error', 'message']
-    */
+     */
     protected function verifyStatusbyid($id)
     {
-        $state['error'] = true; 
-        $query="SELECT status,id FROM {$this->config->table_users} where id = :id";
-        $query_prepared = $this->dbh->prepare($query); 
-        $query_prepared->execute(["id"=>$id]); 
-        $status=$query_prepared->fetch(\PDO::FETCH_ASSOC); 
-        if(!$status){
-            $status['message']= $this->__lang("system_error" . "#21"); 
-        }else{
-            switch($status['status']){
-                case "enabled": 
-                    $state['error']= false; 
-                    $state['message'] = false; 
-                break;
+        $state['error'] = true;
+        $query = "SELECT status,id FROM {$this->config->table_users} where id = :id";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute(["id" => $id]);
+        $status = $query_prepared->fetch(\PDO::FETCH_ASSOC);
+        if (!$status) {
+            $status['message'] = $this->__lang("system_error" . "#21");
+        } else {
+            switch ($status['status']) {
+                case "enabled":
+                    $state['error'] = false;
+                    $state['message'] = false;
+                    break;
                 case "disabled":
-                    $state['message'] = $this->__lang("Account disabled"); 
-                    $this->deleteExistingSessions($status['id']); 
-                break; 
+                    $state['message'] = $this->__lang("Account disabled");
+                    $this->deleteExistingSessions($status['id']);
+                    break;
                 case "deleted":
                     $state['message'] = $this->__lang("system_error" . "#22");
-                    $this->deleteExistingSessions($status['id']); 
-                break; 
+                    $this->deleteExistingSessions($status['id']);
+                    break;
             }
         }
-        return $state; 
+        return $state;
     }
 
     /**
      * Verifies the administrative status 
      * @param string email 
      * @return array $return ['error', 'message']
-    */
-    
+     */
+
     protected function verifyStatus($email)
     {
-        $state['error'] = true; 
-        $query="SELECT status,id FROM {$this->config->table_users} where email = :email";
-        $query_prepared = $this->dbh->prepare($query); 
-        $query_prepared->execute(["email"=>$email]); 
-        $status=$query_prepared->fetch(\PDO::FETCH_ASSOC); 
-        if(!$status){
-            $status['message']= $this->__lang("system_error" . "#21"); 
-        }else{
-            switch($status['status']){
-                case "enabled": 
-                    $state['error']= false; 
-                    $state['message'] = false; 
-                break;
+        $state['error'] = true;
+        $query = "SELECT status,id FROM {$this->config->table_users} where email = :email";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute(["email" => $email]);
+        $status = $query_prepared->fetch(\PDO::FETCH_ASSOC);
+        if (!$status) {
+            $status['message'] = $this->__lang("system_error" . "#21");
+        } else {
+            switch ($status['status']) {
+                case "enabled":
+                    $state['error'] = false;
+                    $state['message'] = false;
+                    break;
                 case "disabled":
-                    $state['message'] = $this->__lang("Account disabled"); 
-                    $this->deleteExistingSessions($status['id']); 
-                break; 
+                    $state['message'] = $this->__lang("Account disabled");
+                    $this->deleteExistingSessions($status['id']);
+                    break;
                 case "deleted":
                     $state['message'] = $this->__lang("system_error" . "#22");
-                    $this->deleteExistingSessions($status['id']); 
-                break; 
+                    $this->deleteExistingSessions($status['id']);
+                    break;
             }
         }
-        return $state; 
+        return $state;
     }
-    
+
 
     /**
-    * Verifies that a password is greater than minimal length
-    *
-    * security requirements (ZxcvbnPhp\Zxcvbn) not checked now.
-    * @param string $password
-    * @return array $return ['error', 'message']
-    */
-    protected function validatePassword($password) {
+     * Verifies that a password is greater than minimal length
+     *
+     * security requirements (ZxcvbnPhp\Zxcvbn) not checked now.
+     * @param string $password
+     * @return array $return ['error', 'message']
+     */
+    protected function validatePassword($password)
+    {
         $state['error'] = true;
 
-        if (strlen($password) < (int)$this->config->verify_password_min_length ) {
+        if (strlen($password) < (int) $this->config->verify_password_min_length) {
             $state['message'] = $this->__lang("password_short");
 
             return $state;
@@ -1333,19 +1335,20 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Verifies that an email is valid
-    * @param string $email
-    * @return array $return
-    */
-    protected function validateEmail($email) {
+     * Verifies that an email is valid
+     * @param string $email
+     * @return array $return
+     */
+    protected function validateEmail($email)
+    {
         $state['error'] = true;
 
-        if (strlen($email) < (int)$this->config->verify_email_min_length ) {
-            $state['message'] = $this->__lang("email_short", (int)$this->config->verify_email_min_length);
+        if (strlen($email) < (int) $this->config->verify_email_min_length) {
+            $state['message'] = $this->__lang("email_short", (int) $this->config->verify_email_min_length);
 
             return $state;
-        } elseif (strlen($email) > (int)$this->config->verify_email_max_length ) {
-            $state['message'] = $this->__lang("email_long", (int)$this->config->verify_email_max_length);
+        } elseif (strlen($email) > (int) $this->config->verify_email_max_length) {
+            $state['message'] = $this->__lang("email_long", (int) $this->config->verify_email_max_length);
 
             return $state;
         } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -1353,8 +1356,8 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
             return $state;
         }
-        
-        if ((int)$this->config->verify_email_use_banlist && $this->isEmailBanned($email)) {
+
+        if ((int) $this->config->verify_email_use_banlist && $this->isEmailBanned($email)) {
             $this->addAttempt();
             $state['message'] = $this->__lang("email_banned");
 
@@ -1368,13 +1371,13 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
 
     /**
-    * Allows a user to reset their password after requesting a reset key.
-    * @param string $key
-    * @param string $password
-    * @param string $repeatpassword
-    * @param string $captcha_response = null
-    * @return array $return
-    */
+     * Allows a user to reset their password after requesting a reset key.
+     * @param string $key
+     * @param string $password
+     * @param string $repeatpassword
+     * @param string $captcha_response = null
+     * @return array $return
+     */
     public function resetPass($key, $password, $repeatpassword, $captcha_response = null)
     {
         $state['error'] = true;
@@ -1408,13 +1411,13 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         $zxcvbn = new Zxcvbn();
-	
+
         if ($zxcvbn->passwordStrength($password)['score'] < intval($this->config->password_min_score)) {
             $state['message'] = $this->__lang('password_weak');
 
             return $state;
         }
-        
+
         if ($password !== $repeatpassword) {
             // Passwords don't match
             $state['message'] = $this->__lang("newpassword_nomatch");
@@ -1429,7 +1432,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
             return $state;
         }
-	    
+
         $data = $this->getRequest($key, "reset");
 
         if ($data['error'] == 1) {
@@ -1457,10 +1460,18 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         $password = $this->getHash($password);
 
-        $query = "UPDATE {$this->config->table_users} SET password = :password WHERE id = :id";
+
+        if ($user['days2expire'] > 0) {
+            $expiration = date("Y-m-d H:i:s", strtotime("now +{$user['days2expire']} days"));
+        } else {
+            $expiration = "0000-00-00 00:00:00";
+        }
+
+        $query = "UPDATE {$this->config->table_users} SET password = :password, expiration = :expiration WHERE id = :id";
         $query_prepared = $this->dbh->prepare($query);
         $query_params = [
             'password' => $password,
+            'expiration' => $expiration,
             'id' => $data['uid']
         ];
         $query_prepared->execute($query_params);
@@ -1471,6 +1482,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
             return $state;
         }
 
+
         $this->deleteRequest($data['id']);
         $state['error'] = false;
         $state['message'] = $this->__lang("password_reset");
@@ -1479,11 +1491,11 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Recreates activation email for a given email and sends
-    * @param string $email
-    * @param null $use_email_activation
-    * @return array $return
-    */
+     * Recreates activation email for a given email and sends
+     * @param string $email
+     * @param null $use_email_activation
+     * @return array $return
+     */
     public function resendActivation($email, $use_email_activation = null)
     {
         $state['error'] = true;
@@ -1515,7 +1527,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         $found_user = $query_prepared->fetch(\PDO::FETCH_ASSOC);
 
-		if(!$found_user) {
+        if (!$found_user) {
             $this->addAttempt();
             $state['message'] = $this->__lang("email_incorrect"); // Really: account not found!
 
@@ -1549,14 +1561,14 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Changes a user's password
-    * @param int $uid
-    * @param string $currpass
-    * @param string $newpass
-    * @param string $repeatnewpass
-    * @param string $captcha_response = null
-    * @return array $return
-    */
+     * Changes a user's password
+     * @param int $uid
+     * @param string $currpass
+     * @param string $newpass
+     * @param string $repeatnewpass
+     * @param string $captcha_response = null
+     * @return array $return
+     */
     public function changePassword($uid, $currpass, $newpass, $repeatnewpass, $captcha_response = null)
     {
         $return['error'] = true;
@@ -1605,8 +1617,8 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         $user = $this->getBaseUser($uid);
-        
-        if(strcmp($user['email'], $newpass)==0){
+
+        if (strcmp($user['email'], $newpass) == 0) {
             $return['message'] = $this->__lang('same_as_email');
 
             return $return;
@@ -1627,17 +1639,17 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         $newpass = $this->getHash($newpass);
-        
-        if($user['days2expire'] > 0 ){
-            $expiration=date("Y-m-d H:i:s", strtotime("now +{$user['days2expire']} days"));
-        } else {
-            $expiration="0000-00-00 00:00:00"; 
-        }
-        
 
-        $query = "UPDATE {$this->config->table_users} SET password = ?, expiration = ?  WHERE id = ?";
+        if ($user['days2expire'] > 0) {
+            $expiration = date("Y-m-d H:i:s", strtotime("now +{$user['days2expire']} days"));
+        } else {
+            $expiration = "0000-00-00 00:00:00";
+        }
+
+
+        $query = "UPDATE {$this->config->table_users} SET password = ?, expiration = ? WHERE id = ?";
         $query_prepared = $this->dbh->prepare($query);
-        $query_prepared->execute([$newpass, $expiraation, $uid]);
+        $query_prepared->execute([$newpass, $expiration, $uid]);
 
         $return['error'] = false;
         $return['message'] = $this->__lang("password_changed");
@@ -1646,13 +1658,13 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Changes a user's email
-    * @param int $uid
-    * @param string $email
-    * @param string $password
-    * @param string $captcha = null
-    * @return array $return
-    */
+     * Changes a user's email
+     * @param int $uid
+     * @param string $email
+     * @param string $password
+     * @param string $captcha = null
+     * @return array $return
+     */
     public function changeEmail($uid, $email, $password, $captcha = null)
     {
         $return['error'] = true;
@@ -1735,9 +1747,9 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Informs if a user is locked out
-    * @return string
-    */
+     * Informs if a user is locked out
+     * @return string
+     */
     public function isBlocked()
     {
         $ip = $this->getIp();
@@ -1801,9 +1813,9 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
 
     /**
-    * Adds an attempt to database
-    * @return boolean
-    */
+     * Adds an attempt to database
+     * @return boolean
+     */
 
     protected function addAttempt()
     {
@@ -1839,18 +1851,18 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     }
 
     /**
-    * Returns a random string of a specified length
-    * @param int $length
-    * @return string $key
-    */
+     * Returns a random string of a specified length
+     * @param int $length
+     * @return string $key
+     */
     public function getRandomKey($length = self::TOKEN_LENGTH)
     {
         $dictionary = "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2W3X4Y5Z6a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6";
         $dictionary_length = strlen($dictionary);
         $key = "";
-        
-	for ($i = 0; $i < $length; $i++) {
-            $key .= $dictionary[ mt_rand(0, $dictionary_length - 1) ];
+
+        for ($i = 0; $i < $length; $i++) {
+            $key .= $dictionary[mt_rand(0, $dictionary_length - 1)];
         }
 
         return $key;
@@ -1895,19 +1907,20 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
      * Returns is user logged in
      * @return boolean
      */
-    public function isLogged() {
+    public function isLogged()
+    {
         if ($this->isAuthenticated === false) {
             $this->isAuthenticated = $this->checkSession($this->getCurrentSessionHash());
         }
         return $this->isAuthenticated;
     }
 
-   /**
-    * Gets user data for current user (from cookie/session_hash) and returns an array, password is not returned
-    * @param bool $updateSession = false
-    * @return array $data
-    * @return boolean false if no current user
-    */
+    /**
+     * Gets user data for current user (from cookie/session_hash) and returns an array, password is not returned
+     * @param bool $updateSession = false
+     * @return array $data
+     * @return boolean false if no current user
+     */
     public function getCurrentUser($updateSession = false)
     {
         if ($this->currentuser === null) {
@@ -1923,28 +1936,28 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
             $this->currentuser = $this->getUser($uid);
         }
-        
+
         if ($updateSession) {
             $this->renewUserSession($hash);
         }
         return $this->currentuser;
     }
-    
+
     /**
      * Update user session expire time using either session hash or uid
      * @param string $hash
      * @param int $uid = null
      * @return
      * 
-    */
-    
-    private function renewUserSession($hash, $uid = null) 
+     */
+
+    private function renewUserSession($hash, $uid = null)
     {
         $expire = date("Y-m-d H:i:s", strtotime($this->config->cookie_remember));
-        
+
         $where = (is_null(($uid))) ? "hash" : "uid";
         $arr = (is_null($uid)) ? $hash : $uid;
-        
+
         $STH = $this->dbh->prepare("UPDATE {$this->config->table_sessions} SET expiredate = ? WHERE {$where} = ?");
         $STH->execute([$expire, $arr]);
 
@@ -1972,7 +1985,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         return password_verify($password_for_check, $data['password']);
     }
-	
+
     /**
      * Check if users password needs to be rehashed
      * @param string $password
@@ -1985,7 +1998,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         if (!password_verify($password, $hash)) {
             return false;
         }
-    
+
         if (password_needs_rehash($hash, PASSWORD_DEFAULT, ['cost' => $this->config->bcrypt_cost])) {
             $hash = $this->getHash($password);
 
@@ -1993,7 +2006,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
             $query_prepared = $this->dbh->prepare($query);
             $query_prepared->execute([$hash, $uid]);
         }
-    
+
         return true;
     }
 
@@ -2064,18 +2077,18 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
             if ($type == 'activation') {
                 $mail->Subject  = $this->__lang('email_activation_subject', $this->config->site_name);
-                if($this->config->site_activation_page_append_code)
-                $url=$this->config->site_activation_page."/".$key;
+                if ($this->config->site_activation_page_append_code)
+                    $url = $this->config->site_activation_page . "/" . $key;
                 else
-                $url=$this->config->site_activation_page;
+                    $url = $this->config->site_activation_page;
                 $mail->Subject  = $this->__lang('email_activation_subject', $this->config->site_name);
                 $mail->Body     = $this->__lang('email_activation_body', $this->config->site_url, $url, $key);
                 $mail->AltBody  = $this->__lang('email_activation_altbody', $this->config->site_url, $url, $key);
             } elseif ($type == 'reset') {
-                if($this->config->site_password_reset_page_append_code)
-                $url=$this->config->site_password_reset_page."/".$key;
+                if ($this->config->site_password_reset_page_append_code)
+                    $url = $this->config->site_password_reset_page . "/" . $key;
                 else
-                $url=$this->config->site_password_reset_page;
+                    $url = $this->config->site_password_reset_page;
                 $mail->Subject  = $this->__lang('email_reset_subject', $this->config->site_name);
                 $mail->Body     = $this->__lang('email_reset_body', $this->config->site_url, $url, $key);
                 $mail->AltBody  = $this->__lang('email_reset_altbody', $this->config->site_url, $url, $key);
@@ -2087,7 +2100,6 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
                 throw new \Exception($mail->ErrorInfo);
 
             $return['error'] = false;
-
         } catch (\Exception $e) {
             $return['message'] = $mail->ErrorInfo;
         }
@@ -2104,14 +2116,14 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
     public function updateUser($uid, $params)
     {
         $setParams = '';
-	
-	//unset uid which is set in getUser(). array generated in getUser() is now usable as parameter for updateUser()
-	unset($params['uid']);
-        if(empty($this->config->tables_params)){
+
+        //unset uid which is set in getUser(). array generated in getUser() is now usable as parameter for updateUser()
+        unset($params['uid']);
+        if (empty($this->config->tables_params)) {
             if (is_array($params) && count($params) > 0) {
-                $setParams = implode(', ', array_map( function($key, $value){
+                $setParams = implode(', ', array_map(function ($key, $value) {
                     return $key . ' = ?';
-                }, array_keys($params), $params ));
+                }, array_keys($params), $params));
             }
 
             $query = "UPDATE {$this->config->table_users} SET {$setParams} WHERE id = ?";
@@ -2126,11 +2138,11 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
                 return $return;
             }
         } else {
-            try { 
-                $json_params=json_encode($this->appyFilterParams($params)); 
-            } catch (\Exception $e){
-                $return['message']=$e->getMessage(); 
-                return $return; 
+            try {
+                $json_params = json_encode($this->appyFilterParams($params));
+            } catch (\Exception $e) {
+                $return['message'] = $e->getMessage();
+                return $return;
             }
             $query = "UPDATE {$this->config->table_users} params = ?  WHERE id = ?";
             $query_prepared = $this->dbh->prepare($query);
@@ -2170,7 +2182,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         $query = $this->dbh->prepare($query);
         $query->execute([
-            'hash'	=>	$this->getCurrentSessionHash()
+            'hash'    =>    $this->getCurrentSessionHash()
         ]);
 
         if ($query->rowCount() == 0) {
@@ -2219,7 +2231,7 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         $this->deleteExpiredSessions();
         $this->deleteExpiredRequests();
     }
-    
+
     /**
      * Add a parameter to be validated by the json object, the object is restricted to be unidimensional, to store pair of $key=>$values
      * @param string    $key the name of the key at the jsob object, cannot be empty and will be sanitized and lowerized
@@ -2229,127 +2241,127 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
      * @param enum      $filter, filter_var php to be applied, options: NONE,  FILTER_SANITIZE_EMAIL, FILTER_SANITIZE_ENCODED, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_SANITIZE_NUMBER_INT, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_SANITIZE_STRING, FILTER_SANITIZE_URL, default NONE 
      * @return array $return[error/message]
      */
-    public function addParam($key=null, $name=null, $required=null, $description=null, $filter="NONE")
+    public function addParam($key = null, $name = null, $required = null, $description = null, $filter = "NONE")
     {
         $return['error'] = true;
-        
-        $filterOptions=array("NONE", "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_ENCODED", "FILTER_SANITIZE_NUMBER_FLOAT", "FILTER_SANITIZE_NUMBER_INT", "FILTER_SANITIZE_SPECIAL_CHARS", "FILTER_SANITIZE_STRING", "FILTER_SANITIZE_URL"); 
-        
-        if(is_null($key)||empty($key)){
-            $return['message'] = $this->__lang("system_error" . "#17"); 
-            return $return ; 
+
+        $filterOptions = array("NONE", "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_ENCODED", "FILTER_SANITIZE_NUMBER_FLOAT", "FILTER_SANITIZE_NUMBER_INT", "FILTER_SANITIZE_SPECIAL_CHARS", "FILTER_SANITIZE_STRING", "FILTER_SANITIZE_URL");
+
+        if (is_null($key) || empty($key)) {
+            $return['message'] = $this->__lang("system_error" . "#17");
+            return $return;
         }
-        if(!in_array($filter, $filterOptions)){
-            $return['message'] = $this->__lang("system_error" . "#18"); 
-            return $return ; 
+        if (!in_array($filter, $filterOptions)) {
+            $return['message'] = $this->__lang("system_error" . "#18");
+            return $return;
         }
-        if(is_null($name)||empty($name)){
-            $name=$key; 
+        if (is_null($name) || empty($name)) {
+            $name = $key;
         }
-        if(is_null($required)||empty($required)||strcmp($required, "n")!=0){
-            $required="y"; 
+        if (is_null($required) || empty($required) || strcmp($required, "n") != 0) {
+            $required = "y";
         }
-        
-        $key=strtolower(str_replace(" ", "", filter_var($key, FILTER_SANITIZE_STRING))); 
+
+        $key = strtolower(str_replace(" ", "", filter_var($key, FILTER_SANITIZE_STRING)));
         $query = "SELECT name,description FROM {$this->config->table_params} WHERE json_key=:key";
         $query_prepared = $this->dbh->prepare($query);
-        if(!$query_prepared->execute(['key' => $key])){
-            $return['message'] = $this->__lang("system_error" . "#19"); 
-            return $return; 
+        if (!$query_prepared->execute(['key' => $key])) {
+            $return['message'] = $this->__lang("system_error" . "#19");
+            return $return;
         }
         $row = $query_prepared->fetch(\PDO::FETCH_ASSOC);
         if ($row) {
-            $return['message'] = $this->__lang("system_error" . "#20"); 
-            $return[$key]=$row; 
-            return $return; 
+            $return['message'] = $this->__lang("system_error" . "#20");
+            $return[$key] = $row;
+            return $return;
         }
-        
-        $query="INSERT INTO {$this->config->table_params} values ( :key, :name, :required, :description, :filter )"; 
-        $query_prepared = $this->dbh->prepare($query); 
-        if(!$query_prepared->execute(['key'=> $key, 'name'=>$name, 'required'=>$required, 'description'=>$description, 'filter'=>$filter ])){
-            $return['message'] = $this->__lang("system_error" . "#21"); 
-            return $return; 
-        }; 
-        $return['message'] = $this->__lang("Key added").": {$key}"; 
+
+        $query = "INSERT INTO {$this->config->table_params} values ( :key, :name, :required, :description, :filter )";
+        $query_prepared = $this->dbh->prepare($query);
+        if (!$query_prepared->execute(['key' => $key, 'name' => $name, 'required' => $required, 'description' => $description, 'filter' => $filter])) {
+            $return['message'] = $this->__lang("system_error" . "#21");
+            return $return;
+        };
+        $return['message'] = $this->__lang("Key added") . ": {$key}";
         $return['error'] = false;
         return $return;
     }
-    
+
     /**
      * Removes a param, always return true... 
      * @return true
-    */
-    public function removeParam($key=null)
+     */
+    public function removeParam($key = null)
     {
-        $query = "DELETE FROM {$this->config->table_params} where json_key=:key"; 
-        $query_prepared=$this->dbh->prepare($query); 
-        $query_prepared->execute(["key"=>$key]);
+        $query = "DELETE FROM {$this->config->table_params} where json_key=:key";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute(["key" => $key]);
         return true;
     }
-    
+
     /**
      * Builds the array to be converted into json_object from the database with the filter aplicable to the value 
      * @return array where key is the json_key from table_params
      */
-     private function buildParams()
-     {
-        $jsonParams=array(); 
-        $query  = "SELECT json_key,filter,required from {$this->config->table_params } order by json_key"; 
-        $query_prepared=$this->dbh->prepare($query); 
-        $query_prepared->execute(); 
-        while($key = $query_prepared->fetch(\PDO::FETCH_ASSOC)){
-            $jsonParams[$key['json_key']]=array("required"=>$key['required'], "filter"=>$key['filter']);
+    private function buildParams()
+    {
+        $jsonParams = array();
+        $query  = "SELECT json_key,filter,required from {$this->config->table_params} order by json_key";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute();
+        while ($key = $query_prepared->fetch(\PDO::FETCH_ASSOC)) {
+            $jsonParams[$key['json_key']] = array("required" => $key['required'], "filter" => $key['filter']);
         }
-        return $jsonParams; 
-     }
-     
-     /**
-       * Filter the params by the defined filter and validate if vale is required,if required, trows and exeption
-       * @returns array built from tables_params definition and sanitizing filter applied
-       */
+        return $jsonParams;
+    }
+
+    /**
+     * Filter the params by the defined filter and validate if vale is required,if required, trows and exeption
+     * @returns array built from tables_params definition and sanitizing filter applied
+     */
     private function appyFilterParams($params)
     {
-        $jsonParams=$this->buildParams();
-        $finalParams=array();
-        foreach($jsonParams as $k=>$v){
-            if(strcmp($v['required'], 'y') == 0 && !isset($params[$k])){
-                throw new \Exception("${k} required but not set"); 
+        $jsonParams = $this->buildParams();
+        $finalParams = array();
+        foreach ($jsonParams as $k => $v) {
+            if (strcmp($v['required'], 'y') == 0 && !isset($params[$k])) {
+                throw new \Exception("${k} required but not set");
             }
-            if(strcmp($v['filter'], 'NONE')==0){
-                $finalParams[$k]= @$params[$k] ? $params[$k] : false; 
+            if (strcmp($v['filter'], 'NONE') == 0) {
+                $finalParams[$k] = @$params[$k] ? $params[$k] : false;
             } else {
-                $finalParams[$k]= @$params[$k] ? filter_var($params[$k], constant($v['filter'])) : false ; 
+                $finalParams[$k] = @$params[$k] ? filter_var($params[$k], constant($v['filter'])) : false;
             }
         }
-        return $finalParams; 
+        return $finalParams;
     }
-     
+
     /**
      * Updates vigency of the password for the user, applys for the next password change
      * @param int $uid 
      * @param int $days2expire, 0 to disable expiration
      * @returns true;
      */
-    public function updateDays2Expire($uid, $days2expire, $doExpiration=false)
+    public function updateDays2Expire($uid, $days2expire, $doExpiration = false)
     {
-        $days2expire=intval($days2expire); 
-        $query="UPDATE {$this->config->table_users} set days2expire = :days2expire where id=:uid"; 
-        $query_prepared=$this->dbh->prepare($query);
-        $query_prepared->execute(['days2expire'=>$days2expire, "uid"=>$uid]);
-        $query="UPDATE {$this->config->table_users} set days2expire = :days2expire where id=:uid"; 
-        if($doExpiration){
-            if($days2expire > 0 ){
-                $expiration=date("Y-m-d 23:59:59", strtotime("now +{$days2expire} days"));
+        $days2expire = intval($days2expire);
+        $query = "UPDATE {$this->config->table_users} set days2expire = :days2expire where id=:uid";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute(['days2expire' => $days2expire, "uid" => $uid]);
+        $query = "UPDATE {$this->config->table_users} set days2expire = :days2expire where id=:uid";
+        if ($doExpiration) {
+            if ($days2expire > 0) {
+                $expiration = date("Y-m-d 23:59:59", strtotime("now +{$days2expire} days"));
             } else {
-                $expiration="0000-00-00 00:00:00"; 
+                $expiration = "0000-00-00 00:00:00";
             }
-            $query="UPDATE {$this->config->table_users} set expiration = :expiration where id=:uid"; 
-            $query_prepared=$this->dbh->prepare($query);
-            $query_prepared->execute(['expiration'=>$expiration, "uid"=>$uid]);
+            $query = "UPDATE {$this->config->table_users} set expiration = :expiration where id=:uid";
+            $query_prepared = $this->dbh->prepare($query);
+            $query_prepared->execute(['expiration' => $expiration, "uid" => $uid]);
         }
         return true;
     }
-    
+
     /**
      * Updates expiration of a password to an arbitrary date
      * @param int   $uid 
@@ -2358,43 +2370,43 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
      */
     public function updateExpiration($uid, $expiration)
     {
-        if(strcmp($expiration, date("Y-m-d", strtotime($expiration)))!=0)
-        return false; 
-        $query="UPDATE {$this->config->table_users} set expiration = :expiration where id=:uid"; 
-        $query_prepared=$this->dbh->prepare($query);
-        $query_prepared->execute(['expiration'=>$expiration." 23:59:59", "uid"=>$uid]); 
+        if (strcmp($expiration, date("Y-m-d", strtotime($expiration))) != 0)
+            return false;
+        $query = "UPDATE {$this->config->table_users} set expiration = :expiration where id=:uid";
+        $query_prepared = $this->dbh->prepare($query);
+        $query_prepared->execute(['expiration' => $expiration . " 23:59:59", "uid" => $uid]);
         return true;
     }
-    
+
     /**
-    * Set secret to be use for jwt
-    * @param string $secret JWT secret key, must comply with Zxcvbn score
-    * @return true,  trow exception if Zxcvbn not satisfied 
-    */
+     * Set secret to be use for jwt
+     * @param string $secret JWT secret key, must comply with Zxcvbn score
+     * @return true,  trow exception if Zxcvbn not satisfied 
+     */
     public function setPrivateKey($secret)
     {
         $zxcvbn = new Zxcvbn();
         if ($zxcvbn->passwordStrength($secret)['score'] < intval($this->config->password_min_score)) {
-            throw new Exception($this->__lang('password_weak'));
+            throw new \Exception($this->__lang('password_weak'));
             return false;
         }
-        $this->private=$secret; 
+        $this->private = $secret;
         return true;
     }
-    
+
     /**
-    * Set public key for RS256 JWT algorithm
-    * @param string public key for RS256 algo 
-    * @return true
-    */
+     * Set public key for RS256 JWT algorithm
+     * @param string public key for RS256 algo 
+     * @return true
+     */
     public function setPublicKey($publicKey)
     {
-        $this->public=$publicKey; 
+        $this->public = $publicKey;
         return true;
     }
-    
-    
-    
+
+
+
     /** 
      * Generate JWT token, 
      * @param $iss string jwt issuer claim
@@ -2403,52 +2415,46 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
      * @param $hash string hashed autentication 
      * @param $callback  array object::function, $hash will be passed as argument, should return an array to be the data payload 
      * @param $return bool jwt token or false 
-    */
-    public function generateJWT($iss, $aud, $remember, $hash, $callback=null)
+     */
+    public function generateJWT($iss, $aud, $remember, $hash, $callback = null)
     {
-        if(!$this->private)
-        {
-            throw new Exception($this->__lang('system_error')); 
-            return false; 
+        if (!$this->private) {
+            throw new Exception($this->__lang('system_error'));
+            return false;
         }
-        if($this->public)
-        {
-            $algo='RS256'; 
+        if ($this->public) {
+            $algo = 'RS256';
+        } else {
+            $algo = 'HS512';
         }
-        else
-        {
-            $algo='HS512'; 
-        }
-        if(!$callback){
-            $params=array("hash"=>$hash); 
-        }else
-        {
-            $uid=$this->getSessionUID($hash); 
-            $user=$this->getBaseUser($uid); 
-            if(!is_array($user)){
-                throw new Exception($this->__lang("system_error")); 
-                exit; 
+        if (!$callback) {
+            $params = array("hash" => $hash);
+        } else {
+            $uid = $this->getSessionUID($hash);
+            $user = $this->getBaseUser($uid);
+            if (!is_array($user)) {
+                throw new \Exception($this->__lang("system_error"));
+                exit;
             }
-            $user["hash"]=$hash; 
-            $params=call_user_func($callback, $user);
-            $params['hash']=$hash;
-            $params['remember']=$remember; 
-            if(!is_array($params)){
-                throw new \Exception($this->__lang('system_error')); 
+            $user["hash"] = $hash;
+            $params = call_user_func($callback, $user);
+            $params['hash'] = $hash;
+            $params['remember'] = $remember;
+            if (!is_array($params)) {
+                throw new \Exception($this->__lang('system_error'));
                 return false;
             }
         }
-        if($remember){
-            $ttl=strtotime($this->config->cookie_remember)-time();
+        if ($remember) {
+            $ttl = strtotime($this->config->cookie_remember) - time();
+        } else {
+            $ttl = strtotime($this->config->cookie_forget) - time();
         }
-        else{
-            $ttl=strtotime($this->config->cookie_forget)-time(); 
-        }
-        
-        
-        $iat=time(); 
-        $nbf=$iat; 
-        $exp=$iat+$ttl; 
+
+
+        $iat = time();
+        $nbf = $iat;
+        $exp = $iat + $ttl;
         $token = array(
             "iss" => $iss,
             "aud" => $aud,
@@ -2456,82 +2462,73 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
             "nbf" => $nbf,
             "exp" => $exp,
             "data" => $params
-            );
+        );
         $jwt = \Firebase\JWT\JWT::encode($token, $this->private, $algo);
         return $jwt;
     }
-    
+
     /**
      * Decode a JWT 
      * @param jwt 
      * @return array decoded data claims, error if invalid jwt
-    */
-     public function decodeJwt($jwt)
-     {
-        if($this->public)
-        {
-            $algo='RS256'; 
-            $key=$this->public;
+     */
+    public function decodeJwt($jwt)
+    {
+        if ($this->public) {
+            $algo = 'RS256';
+            $key = $this->public;
+        } else {
+            $algo = 'HS512';
+            $key = $this->private;
         }
-        else
-        {
-            $algo='HS512'; 
-            $key=$this->private; 
-        }
-        $decode=\Firebase\JWT\JWT::decode($jwt, $key, array($algo));
-        $decode = json_decode(json_encode($decode), true); ; 
-        return $decode; 
-     }
-     
-     /**
-       * Validate jwt token AND hash, hash must inside data claim as an array
-       * @param $jwt string signed token
-       * @return bool true if valid jwt and user false otherwise
-    */
-     
-     public function verifyJwtAuth($jwt)
-     {
-        try 
-        {
-            $decoded=$this->decodeJwt($jwt); 
-            $session=$this->checkSession($decoded['data']['hash'], true);
+        $decode = \Firebase\JWT\JWT::decode($jwt, $key, array($algo));
+        $decode = json_decode(json_encode($decode), true);;
+        return $decode;
+    }
+
+    /**
+     * Validate jwt token AND hash, hash must inside data claim as an array
+     * @param $jwt string signed token
+     * @return bool true if valid jwt and user false otherwise
+     */
+
+    public function verifyJwtAuth($jwt)
+    {
+        try {
+            $decoded = $this->decodeJwt($jwt);
+            $session = $this->checkSession($decoded['data']['hash'], true);
             return $session;
-        } 
-        catch (\UnexpectedValueException $e) 
-        {
-            $message=$e->getMessage(); 
+        } catch (\UnexpectedValueException $e) {
+            $message = $e->getMessage();
             return false;
         }
-     }
-     
-     /**
-       * Validate jwt token AND hash, hash must inside data claim as an array
-       * @param $jwt string signed token
-       * @return bool true if valid jwt and user false otherwise
-    */
-     
-     public function renewJwt($jwt)
-     {
-        try 
-        {
-            $decoded=$this->decodeJwt($jwt); 
-            $session=$this->checkSession($decoded['data']['hash'], true);
-            if($session)
-            {
-                $uid=$this->getSessionUID($decoded['data']['hash']);
-                $this->deleteSession($decoded['data']['hash']);
-                $session=$this->addSession($uid, 0); 
-                $ttl=strtotime($this->config->cookie_forget)-time(); 
-                $data=$decoded['data'];
-                $jwt=$this->generateJWT($decoded['iss'], $decoded['aud'], $data['remember'], $session['hash'], function($user) use ($data) {return $data; }); 
-                return array("error"=>false, "jwt"=>$jwt); 
+    }
 
+    /**
+     * Validate jwt token AND hash, hash must inside data claim as an array
+     * @param $jwt string signed token
+     * @return bool true if valid jwt and user false otherwise
+     */
+
+    public function renewJwt($jwt)
+    {
+        try {
+            $decoded = $this->decodeJwt($jwt);
+            $session = $this->checkSession($decoded['data']['hash'], true);
+            if ($session) {
+                $uid = $this->getSessionUID($decoded['data']['hash']);
+                $this->deleteSession($decoded['data']['hash']);
+                $session = $this->addSession($uid, 0);
+                $ttl = strtotime($this->config->cookie_forget) - time();
+                $data = $decoded['data'];
+                $jwt = $this->generateJWT($decoded['iss'], $decoded['aud'], $data['remember'], $session['hash'], function ($user) use ($data) {
+                    return $data;
+                });
+                return array("error" => false, "jwt" => $jwt);
             }
-            return array("error"=>true, "message"=>$this->__lang("invalid")); 
-        } 
-        catch (\UnexpectedValueException $e) 
-        {
-            return array("error"=>true, "message"=>$e->getMessage()); 
+            return array("error" => true, "message" => $this->__lang("invalid"));
+        } catch (\UnexpectedValueException $e) {
+            return array("error" => true, "message" => $e->getMessage());
         }
-     }     
+    }
 }

--- a/Config.php
+++ b/Config.php
@@ -249,7 +249,15 @@ class Config
 
         return false;
     }
-
+    
+    /**
+      * Config::__isset()
+      * @param $mixed setting
+      * @return false if empty or not set
+    */
+    public function __isset($content) {
+        return isset($this->config[$content]) && !empty($this->config[$content]);
+    }
     /**
      * Config::override()
      *

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The database table `config` contains multiple parameters allowing you to configu
 * `cookie_remember` : the time that a user will remain logged in for when ticking "remember me" on login. Must respect PHP's [strtotime](http://php.net/manual/en/function.strtotime.php) format.
 * `cookie_forget` : the time a user will remain logged in when not ticking "remember me" on login.  Must respect PHP's [strtotime](http://php.net/manual/en/function.strtotime.php) format.
 * `cookie_renew` : the maximum time difference between session expiration and last page load before allowing the session to be renewed. Must respect PHP`s [strtotime](http://php.net/manual/en/function.strtotime.php) format.
+* `days_for_automatic_password_expiration` : Automatic days for expiration of the password, it adds days to time() when creation or password change, for non expiring password, set this value to 0, as global parameter, or `days2expire` to configure per user basis at table `phpauth_users`
 * `allow_concurrent_sessions` : Allow a user to have multiple active sessions (boolean). If false (default), logging in will end any existing sessions.
 * `bcrypt_cost` : the algorithmic cost of the bcrypt hashing function, can be changed based on hardware capabilities
 * `smtp` : `0` to use sendmail for emails, `1` to use SMTP
@@ -137,6 +138,7 @@ The database table `config` contains multiple parameters allowing you to configu
 * `table_requests` : name of the table with all requests (default is 'phpauth_requests')
 * `table_sessions` : name of the table with all sessions (default is 'phpauth_sessions')
 * `table_users` : name of the table with all users (default is 'phpauth_users')
+* `table_params` : name of the table where the description of the json parameters are configured, to be stored in `phpauth_users.params`, if you want to replicate old behavior leave empty, default is `phpauth_params`
 * `table_emails_banned` : name of the table with all banned email domains (default is 'phpauth_emails_banned')
 * `recaptcha_enabled`: 1 for Google reCaptcha enabled, 0 - disabled (default)
 * `recaptcha_site_key`: string, contains public reCaptcha key (for javascripts)
@@ -353,7 +355,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/hajro92"><img src="https://avatars0.githubusercontent.com/u/15570002?v=4" width="100px;" alt=""/><br /><sub><b>Hajrudin</b></sub></a><br /><a href="#translation-hajro92" title="Translation">🌍</a></td>
     <td align="center"><a href="https://github.com/Conver"><img src="https://avatars1.githubusercontent.com/u/6231022?v=4" width="100px;" alt=""/><br /><sub><b>conver</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=conver" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/louis123562"><img src="https://avatars1.githubusercontent.com/u/36068395?v=4" width="100px;" alt=""/><br /><sub><b>louis123562</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=louis123562" title="Documentation">📖</a></td>
-    <td align="center"><a href="http://www.ifscore.info"><img src="https://avatars1.githubusercontent.com/u/4574233?v=4" width="100px;" alt=""/><br /><sub><b>ANDRES TELLO</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=Criptos" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.ifscore.info"><img src="https://avatars1.githubusercontent.com/u/4574233?v=4" width="100px;" alt=""/><br /><sub><b>Criptos</b></sub></a><br /><a href="https://github.com/PHPAuth/PHPAuth/commits?author=Criptos" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The database table `config` contains multiple parameters allowing you to configu
 * `attempts_before_verify` : maximum amount of attempts to be made within `attack_mitigation_time` before requiring captcha. Default is `5`
 * `attempt_before_ban` : maximum amount of attempts to be made within `attack_mitigation_time` before temporally blocking the IP address. Default is `30`
 * `password_min_score` : the minimum score given by [zxcvbn](https://github.com/bjeavons/zxcvbn-php) that is allowed. Default is `3`
+* `default_jwt_iss` : the default issuer claim for jwt token
+* `default_jwt_aud` : the default audience claim for jwt token
 * `translation_source`: source of translation, possible values: 'sql' (data from <table_translations> will be used), 'php' (default, translations will be loaded from languages/*.php), 'ini' (will be used languages/*.ini files)
 * `table_translations` : name of the table with translation for all messages
 * `table_attempts` : name of the table with all attempts (default is 'phpauth_attempts')

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		"php": ">=7.0.0",
 		"bjeavons/zxcvbn-php": "^0.4",
 		"phpmailer/phpmailer": "^6.0",
-	    "google/recaptcha": "^1.2"
+	    "google/recaptcha": "^1.2",
+		"firebase/php-jwt": "^5.2"
 	},
   	"require-dev": {
 	  "phpunit/phpunit": "6.*"

--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -22,6 +22,8 @@ INSERT INTO phpauth_config (setting, value) VALUES ('allow_concurrent_sessions',
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_activation',  '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_reset', '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('mail_charset','UTF-8');
+INSERT INTO phpauth_config (setting, value) VALUES ('default_jwt_iss', '');
+INSERT INTO phpauth_config (setting, value) VALUES ('default_jwt_aud', '');
 INSERT INTO phpauth_config (setting, value) VALUES ('password_min_score',  '3');
 INSERT INTO phpauth_config (setting, value) VALUES ('site_activation_page',  'activate');
 INSERT INTO phpauth_config (setting, value) VALUES ('site_activation_page_append_code', '0');

--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -17,6 +17,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('cookie_path', '/');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_remember', '+1 month');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_secure', '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('cookie_renew', '+5 minutes');
+INSERT INTO phpauth_config (setting, value) VALUES ('days_for_automatic_password_expiration', '30'); 
 INSERT INTO phpauth_config (setting, value) VALUES ('allow_concurrent_sessions', FALSE);
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_activation',  '0');
 INSERT INTO phpauth_config (setting, value) VALUES ('emailmessage_suppress_reset', '0');
@@ -43,6 +44,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('table_attempts',  'phpauth_
 INSERT INTO phpauth_config (setting, value) VALUES ('table_requests',  'phpauth_requests');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_sessions',  'phpauth_sessions');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_users', 'phpauth_users');
+INSERT INTO phpauth_config (setting, value) VALUES ('table_params', 'phpauth_params');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_emails_banned', 'phpauth_emails_banned');
 INSERT INTO phpauth_config (setting, value) VALUES ('table_translations', 'phpauth_translation_dictionary'),
 INSERT INTO phpauth_config (setting, value) VALUES ('verify_email_max_length', '100');
@@ -91,9 +93,25 @@ CREATE TABLE phpauth_users (
   email varchar(100) DEFAULT NULL,
   password varchar(255) DEFAULT NULL,
   isactive smallint DEFAULT 0 NOT NULL,
+  expiration DATETIME YEAR TO SECOND,
+  days2expire smallint DEFAULT 0  NOT NULL,
+  params JSON  DEFAULT '{}', 
+  status varchar(100) DEFAULT NULL,
+  statuschange DATETIME YEAR TO SECOND,  
   dt DATETIME YEAR TO SECOND DEFAULT CURRENT YEAR TO SECOND,
   PRIMARY KEY (id)
 );
+
+
+DROP TABLE phpauth_params;
+CREATE TABLE phpauth_params (
+  json_key varchar(100) DEFAULT '',
+  name varchar(100) DEFAULT '', 
+  required varchar(2) DEFAULT 'y', 
+  description VARCHAR(255) DEFAULT '',
+  filter VARCHAR(255) DEFAULT 'NONE',
+  PRIMARY KEY (json_key)
+)
 
 DROP TABLE phpauth_emails_banned;
 CREATE TABLE phpauth_emails_banned (

--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -97,7 +97,7 @@ CREATE TABLE phpauth_users (
   isactive smallint DEFAULT 0 NOT NULL,
   expiration DATETIME YEAR TO SECOND,
   days2expire smallint DEFAULT 0  NOT NULL,
-  params JSON  DEFAULT '{}', 
+  params JSON DEFAULT NULL, 
   status varchar(100) DEFAULT NULL,
   statuschange DATETIME YEAR TO SECOND,  
   dt DATETIME YEAR TO SECOND DEFAULT CURRENT YEAR TO SECOND,

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -20,6 +20,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('cookie_remember', '+1 month'),
 ('cookie_secure', '0'),
 ('cookie_renew', '+5 minutes'),
+('days_for_automatic_password_expiration', '30'), 
 ('allow_concurrent_sessions', FALSE),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
@@ -47,6 +48,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_requests',  'phpauth_requests'),
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
+('table_params', 'phpauth_params'),
 ('table_emails_banned', 'phpauth_emails_banned'),
 ('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
@@ -95,8 +97,24 @@ CREATE TABLE phpauth_users (
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
+  expiration datetime2 NOT NULL DEFAULT 0,
+  days2expire smallint UNSIGNED NOT NULL DEFAULT 0,
+  params nvarchar(max) NOT NULL DEFAULT '{}', 
+  status character varying(20) DEFAULT NULL,
+  statuschange datetime2 NOT NULL DEFAULT 0,  
   dt datetime2 NOT NULL DEFAULT GETDATE(),
   PRIMARY KEY (id)
+);
+
+
+DROP TABLE IF EXISTS `phpauth_params`;
+CREATE TABLE `phpauth_params` (
+  `json_key` character varying(100) DEFAULT '',
+  `name` character varying(100) DEFAULT '', 
+  `required` character varying(2) DEFAULT 'y', 
+  `description` character varying(255) DEFAULT '',
+  `filter` character varying(100) DEAULT 'NONE',
+  PRIMARY KEY (`json_key`)
 );
 
 DROP TABLE IF EXISTS phpauth_emails_banned;

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -25,6 +25,8 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
 ('mail_charset','UTF-8'),
+('default_jwt_iss', ''), 
+('default_jwt_aud', ''), 
 ('password_min_score',  '3'),
 ('site_activation_page',  'activate'),
 ('site_activation_page_append_code', '0'),

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -101,7 +101,7 @@ CREATE TABLE phpauth_users (
   isactive smallint NOT NULL DEFAULT '0',
   expiration datetime2 NOT NULL DEFAULT 0,
   days2expire smallint UNSIGNED NOT NULL DEFAULT 0,
-  params nvarchar(max) NOT NULL DEFAULT '{}', 
+  params nvarchar(max) NULL, 
   status character varying(20) DEFAULT NULL,
   statuschange datetime2 NOT NULL DEFAULT 0,  
   dt datetime2 NOT NULL DEFAULT GETDATE(),

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -27,6 +27,7 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('cookie_remember', '+1 month'),
   ('cookie_secure', '0'),
   ('cookie_renew', '+5 minutes'),
+  ('days_for_automatic_password_expiration', '30'), 
   ('allow_concurrent_sessions', FALSE),
   ('emailmessage_suppress_activation',  '0'),
   ('emailmessage_suppress_reset', '0'),
@@ -54,6 +55,7 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('table_requests',  'phpauth_requests'),
   ('table_sessions',  'phpauth_sessions'),
   ('table_users', 'phpauth_users'),
+  ('table_params', 'phpauth_params'),
   ('table_emails_banned', 'phpauth_emails_banned'),
   ('table_translations', 'phpauth_translation_dictionary'),
   ('verify_email_max_length', '100'),
@@ -114,9 +116,28 @@ CREATE TABLE `phpauth_users` (
   `email` varchar(100) DEFAULT NULL,
   `password` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
   `isactive` tinyint(1) NOT NULL DEFAULT '0',
+  `expiration` timestamp NOT NULL DEFAULT 0,
+  `days2expire` int(3) UNSIGNED NOT NULL DEFAULT 0,
+  `params` JSON NOT NULL DEFAULT '{}', 
+  `status` enum ('enabled', 'disabled', 'deleted') DEFAULT 'enabled', 
+  `statuschange` timestamp NOT NULL DEFAULT 0,
   `dt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `email` (`email`)
+  KEY `email` (`email`), 
+  KEY `expiration` (`expiration`),
+  KEY `exporationstatus` (`expiration`, `status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- User Parameters Table
+
+DROP TABLE IF EXISTS `phpauth_params`;
+CREATE TABLE `phpauth_params` (
+  `json_key` varchar(100) DEFAULT '',
+  `name` varchar(100) DEFAULT '', 
+  `required` enum('y', 'n') DEFAULT 'y', 
+  `description` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
+  `filter` enum('NONE', 'FILTER_SANITIZE_EMAIL', 'FILTER_SANITIZE_ENCODED', 'FILTER_SANITIZE_NUMBER_FLOAT', 'FILTER_SANITIZE_NUMBER_INT', 'FILTER_SANITIZE_SPECIAL_CHARS', 'FILTER_SANITIZE_STRING', 'FILTER_SANITIZE_URL') default 'NONE',  
+  PRIMARY KEY (`json_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Banned emails reference

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -32,6 +32,8 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('emailmessage_suppress_activation',  '0'),
   ('emailmessage_suppress_reset', '0'),
   ('mail_charset','UTF-8'),
+  ('default_jwt_iss', ''), 
+  ('default_jwt_aud', ''), 
   ('password_min_score',  '3'),
   ('site_activation_page',  'activate'),
   ('site_activation_page_append_code', '0'), 

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -120,7 +120,7 @@ CREATE TABLE `phpauth_users` (
   `isactive` tinyint(1) NOT NULL DEFAULT '0',
   `expiration` timestamp NOT NULL DEFAULT 0,
   `days2expire` int(3) UNSIGNED NOT NULL DEFAULT 0,
-  `params` JSON NOT NULL DEFAULT '{}', 
+  `params` JSON DEFAULT NULL, 
   `status` enum ('enabled', 'disabled', 'deleted') DEFAULT 'enabled', 
   `statuschange` timestamp NOT NULL DEFAULT 0,
   `dt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -25,6 +25,8 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
 ('mail_charset','UTF-8'),
+('default_jwt_iss', ''), 
+('default_jwt_aud', ''), 
 ('password_min_score',  '3'),
 ('site_activation_page',  'activate'),
 ('site_activation_page_append_code', '0'), 

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -20,6 +20,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('cookie_remember', '+1 month'),
 ('cookie_secure', '0'),
 ('cookie_renew', '+5 minutes'),
+('days_for_automatic_password_expiration', '30'), 
 ('allow_concurrent_sessions', FALSE),
 ('emailmessage_suppress_activation',  '0'),
 ('emailmessage_suppress_reset', '0'),
@@ -47,6 +48,7 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('table_requests',  'phpauth_requests'),
 ('table_sessions',  'phpauth_sessions'),
 ('table_users', 'phpauth_users'),
+('table_params', 'phpauth_params'),
 ('table_emails_banned', 'phpauth_emails_banned'),
 ('table_translations', 'phpauth_translation_dictionary'),
 ('verify_email_max_length', '100'),
@@ -97,6 +99,11 @@ CREATE TABLE phpauth_users (
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
+  expiration timestamp without time zone NOT NULL,
+  days2expire integer UNSIGNED NOT NULL DEFAULT 0,
+  params JSON NOT NULL DEFAULT '{}', 
+  status character varying(10), 
+  statuschange timestamp without time zone NOT NULL,  
   dt timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 );

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -103,7 +103,7 @@ CREATE TABLE phpauth_users (
   isactive smallint NOT NULL DEFAULT '0',
   expiration timestamp without time zone NOT NULL,
   days2expire integer UNSIGNED NOT NULL DEFAULT 0,
-  params JSON NOT NULL DEFAULT '{}', 
+  params JSON NULL, 
   status character varying(10), 
   statuschange timestamp without time zone NOT NULL,  
   dt timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
# Configuration directives
`days_for_automatic_password_expiration` number of default days before password expiration, if set  to 0 password globally doesn't expire.
`phpauth_params` table to storage json structure of field params, if empty use old behavior requiring  modifying the table to accept params. 
`default_jwt_iss`   the default issuer claim for jwt token
`default_jwt_aud`  the default audience claim for jwt token

# Table changes to `phpauth_users`
`expiration` datetime: date after which the password is considered as expired.
`days2expire` int(3):  per user configuration, when used is created by default uses configuration option of `days_for_automatic_password_expiration` if set to 0, pass
word does't expire. This is a per user configuration.
`params` JSON: Storage of the fields described by `phpauth_params`, as a json_object.
`status` enum ('enabled', 'disabled', 'deleted'): Administrative status of the account
`statuschange` timestamp: date of the last chage of status 

# New Table `phpauth_params` 
```
DROP TABLE IF EXISTS `phpauth_params`;
CREATE TABLE `phpauth_params` (
  `json_key` varchar(100) DEFAULT '',
  `name` varchar(100) DEFAULT '', 
  `required` enum('y', 'n') DEFAULT 'y', 
  `description` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
  `filter` enum('NONE', 'FILTER_SANITIZE_EMAIL', 'FILTER_SANITIZE_ENCODED', 'FILTER_SANITIZE_NUMBER_FLOAT', 'FILTER_SANITIZE_NUMBER_INT', 'FILTER_SANITIZE_SPECIAL_CHA
RS', 'FILTER_SANITIZE_STRING', 'FILTER_SANITIZE_URL') default 'NONE',  
  PRIMARY KEY (`json_key`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

# Administrative status management. 
Use case: Management required fine gran control over user accounts. 
This is a flag, if an account is disabled, when the  user tries to login a disable account message is generated. 
If the user deletes the account, the status delete is enabled, instead of deleting  the account. The `purgeUser` function is created to remove the user from the datab
ase. 

* disable($email) to disable the account by email 
* enable($email) to enable the account by email 
* deleteUser($uid, $password, $captcha_response = null)  set the account status to deleted 
* deleteUserForced($uid) set the account status to deleted
* purgeUser($uid) remove the user from the database 
* verifyStatus($email)  protected function to verify the status, no error on enabled status, error on disabled and deleted
 
# Automatic passsword expiration. 
Use case: Passwords are required to expire automatically. 
Use case: Expiration days is a parameter settable per user. 

This functionally can be disabled globally if configuration value `days_for_automatic_password_expiration` is set to 0. 
When the user is created the configuration value `days_for_automatic_password_expiration` is propagated to the `phpauth_user.days2expire` and the password expiration 
date is set to now() + days2expire days. 

If the `phpauth_user.days2expire` is set to 0, the password doesn't expire. 

* updateDays2Expire($uid, $days2expire, $doExpiration=false) set the days2expire for the user $uid, if $doExpiration is set to true, the expiration date is also updat
ed, using as reference now() 
* updateExpiration($uid, $expiration) set an arbitrary expiration date, the format is YYYY-MM-DD, accepts date in the past to force expiration. 

# Email as password validation
Use case: Password and email can't be the same. 
Validated for user creation and password change

# Json storage of params.
Use case: PHPAuth must be deployed as dynamic microservice authentication. 
Use case: PHPAuth should be used by everyone, avoiding alteration of system tables. 
Disclaimer: This is not a replacement for a separate table to hold all the user details, on behalf security, the user credentials and the user details should live in 
separate server limit the data leakage, the json data should be the minimal data to identify the user. 

Parameters can be added to `table_params` using the function addParam(), the arguments are:
* addParam($key=null, $name=null, $required=null, $description=null, $filter="NONE")
  *  $key the name of the key at the json object, cannot be empty and will be sanitized and lowerized
  *  $name human name of the variable, suitable for UI, if empty, key will be used instead 
  *  $required y/n, default y,  
  *  $description description of the filed, human redeable, suitable for UI, can be empty
  *  $filter, filter_var php to be applied, options: NONE,  FILTER_SANITIZE_EMAIL, FILTER_SANITIZE_ENCODED, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_SANITIZE_NUMBER_INT, 
FILTER_SANITIZE_SPECIAL_CHARS, FILTER_SANITIZE_STRING, FILTER_SANITIZE_URL, default NONE 
* removeParam($key=null) removes the parameter from the table `table_params`
* buildParams() prepares an array as skeleton used to validate the user params. 
* appyFilterParams($params) match the params to the array built by `buildParams()`, if a parameter is set as required but not present, an error is throw and no data i
s updated. 

**To disable this behavior, set the configuration option `table_params` to '' (empty)**

# System error added or updated
(addParam) Key null or empty #17 
(addParam) filter not valir #18
(addParam) Key select query failed #19
(addParam) Duplicated key #20
(addParam) Inser failed to table_param #21
(login)    Account is  deleted my administration #22
(deleteUser) Failed to delete user from user table #05
(disable) Failed to update table #23
(enable)  Failer to update table #24

# Config.php & emtpy 
Config.php uses the magic method of __set, so to test for emtpy, more magic is needed, so magic function __isset is defined to enable the correct functionality of iss
et and empty. 
Ref: https://www.tutorialdocs.com/article/16-php-magic-methods.html

# JWT Token 
Use Case: PHPAuth must issue JWT compatibel tokens. 
Use Case: PHP Auth must decide between  HS512 or RS256  algorithms, based on configuration options. 
Dependency added: firebase/jwt
Two new variables where added to the object PHPAuth, private and public keys for JWT 
The JWT usage is assumed to be used by SPA. 
The JWT will add the hash and remember to the data payload by default 
Also, arbitrary data can be added by callback. The return value of callback at applogin, must return an array.

* function setPrivateKey($key)  set the private key for JWT encoding 
* function setPublicKey($key) set the public decryption key to use RS256 algorithm.
* function appLogin($email, $password, $remember = 0, $captcha_response = null, $callback=false, $iss=null, $aud=null) to login the user, 
 * `$callback` is a callback to a user function which return an array with arbitrary data. callback gets $this->baseuser information set as parameter. 
 * `$iss` is to set the issuer claim and 
 * `$aud` to set the audience claim
If successful login, appLogin will return an array of (error=>false, and jwt) to be sent to the client. 

* function decodeJwt($jwt) used to deode the token with the $this->private or $this->public if configured. 
* function verifyJwtAuth($jwt) verifys the validity of the token and the session and user set by data['hash']
* function renewJW($jwt) renews the token and the underlying database session, it generates a new hash and new token 



