### PR TITLE
Added global password expiration

### DIFF
--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -55,6 +55,7 @@ INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_enabled', 0);
 INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_site_key', '');
 INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_secret_key', 'php');
 INSERT INTO phpauth_config (setting, value) VALUES ('custom_datetime_format', 'Y-m-d H:i');
+INSERT INTO phpauth_config (setting, value) VALUES ('user_password_valid_for', NULL);
 
 DROP TABLE phpauth_attempts;
 CREATE TABLE phpauth_attempts (
@@ -92,6 +93,7 @@ CREATE TABLE phpauth_users (
   id SERIAL,
   email varchar(100) DEFAULT NULL,
   password varchar(255) DEFAULT NULL,
+  password_valid_until DATETIME YEAR TO SECOND DEFAULT NULL,
   isactive smallint DEFAULT 0 NOT NULL,
   dt DATETIME YEAR TO SECOND DEFAULT CURRENT YEAR TO SECOND,
   PRIMARY KEY (id)

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -58,7 +58,8 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('recaptcha_enabled', 0),
 ('recaptcha_site_key', ''),
 ('recaptcha_secret_key', ''),
-('custom_datetime_format', 'Y-m-d H:i');
+('custom_datetime_format', 'Y-m-d H:i'),
+('user_password_valid_for', NULL);
 
 DROP TABLE IF EXISTS phpauth_attempts;
 CREATE TABLE phpauth_attempts (
@@ -96,6 +97,7 @@ CREATE TABLE phpauth_users (
   id int NOT NULL IDENTITY(1,1),
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
+  password_valid_until datetime2 DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
   dt datetime2 NOT NULL DEFAULT GETDATE(),
   PRIMARY KEY (id)

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -65,7 +65,8 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('recaptcha_enabled', 0),
   ('recaptcha_site_key', ''),
   ('recaptcha_secret_key', ''),
-  ('custom_datetime_format', 'Y-m-d H:i');
+  ('custom_datetime_format', 'Y-m-d H:i'),
+  ('user_password_valid_for', NULL);
 
 -- Attempts table
 
@@ -115,6 +116,7 @@ CREATE TABLE `phpauth_users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `email` varchar(100) DEFAULT NULL,
   `password` VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
+  `password_valid_until` timestamp DEFAULT NULL,
   `isactive` tinyint(1) NOT NULL DEFAULT '0',
   `dt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -58,7 +58,8 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('recaptcha_enabled', 0),
 ('recaptcha_site_key', ''),
 ('recaptcha_secret_key', ''),
-('custom_datetime_format', 'Y-m-d H:i');
+('custom_datetime_format', 'Y-m-d H:i'),
+('user_password_valid_for', NULL);
 
 DROP TABLE IF EXISTS phpauth_attempts;
 CREATE TABLE phpauth_attempts (
@@ -98,6 +99,7 @@ CREATE TABLE phpauth_users (
   id serial NOT NULL,
   email character varying(100) DEFAULT NULL,
   password character varying(255) DEFAULT NULL,
+  password_valid_until timestamp without time zone DEFAULT NULL,
   isactive smallint NOT NULL DEFAULT '0',
   dt timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id)

--- a/languages/de_DE.php
+++ b/languages/de_DE.php
@@ -46,6 +46,7 @@ $lang['resetkey_invalid'] = "Der Sicherheitsschlüssel ist ungültig.";
 $lang['resetkey_incorrect'] = "Der Sicherheitsschlüssel ist nicht korrekt.";
 $lang['resetkey_expired'] = "Der Sicherheitsschlüssel ist abgelaufen.";
 $lang['password_reset'] = "Ihr Passwort wurde erfolgreich zurückgesetzt.";
+$lang['password_expired'] = "Ihr Passwort ist abgelaufen.";
 
 $lang['activationkey_invalid'] = "Der Aktivierungsschlüssel ist ungültig.";
 $lang['activationkey_incorrect'] = "Der Aktivierungsschlüssel ist nicht korrekt.";

--- a/languages/en_GB.php
+++ b/languages/en_GB.php
@@ -46,6 +46,7 @@ $lang['resetkey_invalid'] = "Reset key is invalid.";
 $lang['resetkey_incorrect'] = "Reset key is incorrect.";
 $lang['resetkey_expired'] = "Reset key has expired.";
 $lang['password_reset'] = "Password reset successfully.";
+$lang['password_expired'] = "Your password is expired.";
 
 $lang['activationkey_invalid'] = "Activation key is invalid.";
 $lang['activationkey_incorrect'] = "Activation key is incorrect.";


### PR DESCRIPTION
if the new config parameter 'user_password_valid_for' is set to a date_string like '+1 month', the expiration is active.

there is also a new table column at the 'phpauth_users' table, called 'password_valid_until' which is a timestampt. It get*s updatet by the resetPass() function.

the login() function checks, if the password of a user is expired an returns error = true and also if the password is expired -> $return['password_expired'] = true;