### PR TITLE
basic google authentication

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -2552,25 +2552,20 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         $return_arr = [];
         $return_arr['error'] = true;
         $return_arr['message'] = "unknown error";
-
         $pay_load = null;
 
         //create google auth object
         $g_client = new \Google\Client();
 
-        $g_client->setClientId("");
-        $g_client->setClientSecret("");
-        $g_client->setRedirectUri("");
+        $g_client->setClientId($this->config->google_client_id);
+        $g_client->setClientSecret($this->config->google_client_secret);
+        $g_client->setRedirectUri($this->config->google_redirect_url);
         $g_client->addScope("email");
 
-        $pay_load = null; //Wird zum Array mit Mitarbeiterinformationen aus Google-Datenbank
+        $pay_load = null;
 
         try {
-
-            //Mit dem Code den Auth-Code abrufen
             $googleToken = $g_client->fetchAccessTokenWithAuthCode($code);
-
-            //Token setzen
             $g_client->setAccessToken($googleToken);
         } catch (\Exception $e) {
             error_log($e);
@@ -2578,30 +2573,20 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         }
 
         try {
-
-            //Den Auth-Token verifizieren
             $pay_load = $g_client->verifyIdToken();
         } catch (\Exception $e) {
             error_log($e);
             return $return_arr;
         }
 
-        //Wenn die Informationen zum Benutzer nicht leer sind
         if ($pay_load !== null) {
-
-            error_log("PAYLOAD IST NICHT NULL!");
-            error_log("PAYLOAD:");
             error_log(print_r($pay_load, true));
-
-            //Aus dem PayLoad die E-Mail übernehmen
             $google_mail = $pay_load["email"];
         } else {
             error_log("PAYLOAD LEER");
+            $return_arr['message'] = "payload empty";
+            return $return_arr;
         }
-
-        //-----------------------------------------------------------------------------------------------------------------------
-        // GET USER ID VIA EMAIL RETURNED BY GOOGLE
-        //-----------------------------------------------------------------------------------------------------------------------
 
         $query = "SELECT id FROM {$this->config->table_users} WHERE email = :email";
         $query_prepared = $this->dbh->prepare($query);
@@ -2611,21 +2596,14 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
 
         $data = $query_prepared->fetch(\PDO::FETCH_ASSOC);
 
-        // error_log(print_r($data, true));
-
         if (!isset($data['id'])) {
             $return_arr['message'] = "Account with given email not present in users-table";
             return $return_arr;
         }
 
-        //-----------------------------------------------------------------------------------------------------------------------
-        // ADD SESSION
-        //-----------------------------------------------------------------------------------------------------------------------
-
-        $result_add_session = $this->addSession($data['id'], true); //FIXME true oder false?
+        $result_add_session = $this->addSession($data['id'], true);
 
         if ($result_add_session['error'] == true) {
-            error_log("your fucked!");
             $return_arr['message'] = "could not add Session";
             return $return_arr;
         }
@@ -2647,16 +2625,14 @@ VALUES (:uid, :hash, :expiredate, :ip, :agent, :cookie_crc)
         $return_arr = [];
         $return_arr['error'] = true;
         $return_arr['auth_url'] = null;
-
         $auth_url = null;
 
-        //Google-Objekt anlegen
         $g_client = new \Google\Client();
 
         try {
-            $g_client->setClientId("");
-            $g_client->setClientSecret("");
-            $g_client->setRedirectUri("");
+            $g_client->setClientId($this->config->google_client_id);
+            $g_client->setClientSecret($this->config->google_client_secret);
+            $g_client->setRedirectUri($this->config->google_redirect_url);
             $g_client->addScope("email");
 
             $auth_url = $g_client->createAuthUrl();

--- a/database_defs/database_informix.sql
+++ b/database_defs/database_informix.sql
@@ -59,6 +59,9 @@ INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_enabled', 0);
 INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_site_key', '');
 INSERT INTO phpauth_config (setting, value) VALUES ('recaptcha_secret_key', 'php');
 INSERT INTO phpauth_config (setting, value) VALUES ('custom_datetime_format', 'Y-m-d H:i');
+INSERT INTO phpauth_config (setting, value) VALUES ('google_client_id', null);
+INSERT INTO phpauth_config (setting, value) VALUES ('google_client_secret', null);
+INSERT INTO phpauth_config (setting, value) VALUES ('google_redirect_url', null);
 
 DROP TABLE phpauth_attempts;
 CREATE TABLE phpauth_attempts (

--- a/database_defs/database_mssql.sql
+++ b/database_defs/database_mssql.sql
@@ -62,7 +62,10 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('recaptcha_enabled', 0),
 ('recaptcha_site_key', ''),
 ('recaptcha_secret_key', ''),
-('custom_datetime_format', 'Y-m-d H:i');
+('custom_datetime_format', 'Y-m-d H:i'),
+('google_client_id', null),
+('google_client_secret', null),
+('google_redirect_url', null;
 
 DROP TABLE IF EXISTS phpauth_attempts;
 CREATE TABLE phpauth_attempts (

--- a/database_defs/database_mysql.sql
+++ b/database_defs/database_mysql.sql
@@ -69,7 +69,10 @@ INSERT INTO `phpauth_config` (`setting`, `value`) VALUES
   ('recaptcha_enabled', 0),
   ('recaptcha_site_key', ''),
   ('recaptcha_secret_key', ''),
-  ('custom_datetime_format', 'Y-m-d H:i');
+  ('custom_datetime_format', 'Y-m-d H:i'),
+  ('google_client_id', null),
+  ('google_client_secret', null),
+  ('google_redirect_url', null;
 
 -- Attempts table
 

--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -62,7 +62,10 @@ INSERT INTO phpauth_config (setting, value) VALUES
 ('recaptcha_enabled', 0),
 ('recaptcha_site_key', ''),
 ('recaptcha_secret_key', ''),
-('custom_datetime_format', 'Y-m-d H:i');
+('custom_datetime_format', 'Y-m-d H:i'),
+('google_client_id', null),
+('google_client_secret', null),
+('google_redirect_url', null;
 
 DROP TABLE IF EXISTS phpauth_attempts;
 CREATE TABLE phpauth_attempts (


### PR DESCRIPTION
added two functions:

## getGoogleAuthURL()

Generates a URL which points to the google-login form provided by google. You can use it with HTML-link like

```
//get url
$result = $auth->getGoogleAuthURL();

//check if url-generating was okay
if($result['error'] == false){
    echo "<a href='" . $result['auth_url']. "'>Login via Google</a>
}

```

## authenticateViaGoogle()

Verifies the authentication-code that is bound to the redirect-url as a get parameter, that it is a successfull authentication. Checks via scope (at the moment fixed 'email') if the google-account is bound to a phpauth-users (both need to have the same e-mail-address). Adds a session + cookie and returns the result. Small example code of how to use:

```
if(isset($_GET['code'])){
   $result = $auth->authenticateViaGoogle($_GET['code']);

   if($result['error'] == false){
      //locate to your application
      header("Location: /");
   }
}
```

## TODO

check if google-parameter are present (not null)

**PLEASE FEEL FREE TO COMMENT & IMPROVE THIS SOLUTION!**