### PR TITLE
zxcvbn bump version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.0.0",
-    "bjeavons/zxcvbn-php": "^0.4",
+    "bjeavons/zxcvbn-php": "^1.0",
     "phpmailer/phpmailer": "^6.0",
     "google/recaptcha": "^1.2",
     "ext-pdo": "*"


### PR DESCRIPTION
zxcvbn-php bump version from 0.4 to 1.0. PHP support 7.0