### PR TITLE
CHANGE: Remove return type from __set() method #484

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -250,7 +250,7 @@ class Config
      *
      * @return bool
      */
-    public function __set(string $setting, $value) : bool
+    public function __set(string $setting, $value)
     {
         $query_prepared = $this->dbh->prepare("UPDATE {$this->config_table} SET value = :value WHERE setting = :setting");
 


### PR DESCRIPTION
From issue https://github.com/PHPAuth/PHPAuth/issues/484

> With PHP 8.0.1 (but not PHP 7.4.14), Config.php doesn't compile because the return type specified for the __set() method, declared as "bool", so offends the compiler that it throws a fatal error with this message:
> 
> PHP Fatal error: PHPAuth\Config::__set(): Return type must be void when declared in /home/rose/public_html/phpauth/vendor/phpauth/phpauth/Config.php on line 253

I have removed the return value. With or without will make no difference.