### PR TITLE
Fix syntax in postgres dump file

### DIFF
--- a/database_defs/database_pgsql.sql
+++ b/database_defs/database_pgsql.sql
@@ -88,7 +88,7 @@ CREATE TABLE phpauth_sessions (
   hash character (40) NOT NULL,
   expiredate timestamp without time zone NOT NULL,
   ip character varying(39) NOT NULL,
-  device_id varchar varying(36) DEFAULT NULL,
+  device_id character varying(36) DEFAULT NULL,
   agent character varying(200) NOT NULL,
   cookie_crc character (40) NOT NULL,
   PRIMARY KEY (id)


### PR DESCRIPTION
The `character varying` data type can also be written as `varchar` but there's this one line that's written `varchar varying` that stopped the db initialization for me. This commit just changes it to the long form that is used throughout the rest of the file.

_PS: I still ended up having to switch to MySQL anyways though because apparently the backtick quoting used in queries has a totally different meaning in PostgreSQL... which makes it incompatible unless you go through and replace all the backticks used in this library._