### PR TITLE
 MySQL execute check #518

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -420,7 +420,7 @@ class Auth
 
     /**
      * Gets UID for a given email address or zero if email not found
-     
+
      * @param string $email
      * @return int $uid
      */
@@ -429,9 +429,9 @@ class Auth
         $query = "SELECT id FROM {$this->config->table_users} WHERE email = :email";
         $query_prepared = $this->dbh->prepare($query);
         $query_prepared->execute(['email' => strtolower($email)]);
-        
+
         $uid = $query_prepared->fetchColumn();
-        
+
         return $uid === false ? 0 : $uid;
     }
 
@@ -575,13 +575,16 @@ class Auth
         $query_params = [
             'hash' => $hash
         ];
-        $query_prepared->execute($query_params);
 
-        if ($query_prepared->rowCount() == 0) {
+        if (!$query_prepared->execute($query_params)) {
             return false;
         }
 
         $row = $query_prepared->fetch(PDO::FETCH_ASSOC);
+
+        if (empty($row)) {
+            return false;
+        }
 
         $uid = $row['uid'];
         $expiredate = strtotime($row['expiredate']);
@@ -630,10 +633,9 @@ class Auth
         $query_params = [
             'hash' => $hash
         ];
-        $query_prepared->execute($query_params);
 
-        if ($query_prepared->rowCount() == 0) {
-            return 0;
+        if (!$query_prepared->execute($query_params)) {
+            return false;
         }
 
         return (int)$query_prepared->fetch(PDO::FETCH_ASSOC)['uid'];

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -248,6 +248,7 @@ class AuthTest extends TestCase
     }
 
     /**
+     * @depends testLogin
      * @depends testChangeEmail
      */
     public function testLogout()


### PR DESCRIPTION
Check sql failures with a simple if statement
```php
if (!$query_prepared->execute($query_params)) {}
```

Add missing dependency (phpunit test):
```
@depends testLogin
```