### PR TITLE
fix ip address

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -1622,7 +1622,7 @@ class Auth
     }
 
     /**
-     * Returns IP address
+     * Returns IP address of client
      * @return string $ip
      */
     protected function getIp(): string
@@ -1642,6 +1642,8 @@ class Auth
         } else {
             $ipAddress = '127.0.0.1';
         }
+
+        $ipAddress = explode(',', $ipAddress);
 
         return $ipAddress;
     }

--- a/Auth.php
+++ b/Auth.php
@@ -1643,7 +1643,7 @@ class Auth
             $ipAddress = '127.0.0.1';
         }
 
-        $ipAddress = explode(',', $ipAddress);
+        $ipAddress = explode(',', $ipAddress)[0];
 
         return $ipAddress;
     }


### PR DESCRIPTION
i use proxies in front of my websers and the function getIp() returned a list of ip addresses instead of a single one. this caused a PDO exception (truncated data).

It now returns the first ip address of the list.