### PR TITLE
Resolve null setcookie value for PHP 8+

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -541,7 +541,7 @@ class Auth
             unset($_COOKIE[$this->config->cookie_name]);
         }
 
-        if (!setcookie($this->config->cookie_name, null, -1, '/')) {
+        if (!setcookie($this->config->cookie_name, '', -1, '/')) {
             return false;
         }
 


### PR DESCRIPTION
# Description
Running the current version of PHPAuth on PHP 8.1.2 results in a notice from the framework stating that null values can no longer be supplied to the second parameter of setcookie. This causes the framework to return a 500 error. Making this small change allows the framework in its current state to operate on PHP 8.1

# Documentation
https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation
https://www.php.net/manual/en/function.setcookie.php