### PR TITLE
fix : not found for `verify.no_pair_user_and_password`

### DIFF
--- a/sources/Auth.php
+++ b/sources/Auth.php
@@ -145,7 +145,7 @@ class Auth implements AuthInterface
 
         if (!$this->password_verify_with_rehash($password, $user['password'], $uid)) {
             $this->addAttempt();
-            $return['message'] = $this->__lang('verify.no_pair_user_and_password');
+            $return['message'] = $this->__lang('account.no_pair_user_and_password');
             return $return;
         }
 


### PR DESCRIPTION
not found for `verify.no_pair_user_and_password`
see:
https://github.com/PHPAuth/PHPAuth/blob/df1c90f60987cb9e752d085c7ddd1a3ad56129e1/sources/Helpers.php#L182-L205